### PR TITLE
Update 21.08 API docs

### DIFF
--- a/api/_build/README.md
+++ b/api/_build/README.md
@@ -24,7 +24,7 @@ The scripts in this directory add the content from this repo to the spec, and th
 
     This step generates a file called `openapi_enriched.json`.
 
-   `$ python enrich_spec.py ./openapi_supported.json`
+   `$ python enrich_spec.py ./openapi_supported.json ../_topic_map.yml`
 
 1. Prepare the spec for publication on prisma.pan.dev.
 

--- a/api/_build/supported.cfg
+++ b/api/_build/supported.cfg
@@ -13,8 +13,6 @@
 /cloud/discovery/progress,get
 /cloud/discovery/scan,post
 /cloud/discovery/stop,post
-/coderepos-ci,post
-/coderepos-ci/evaluate,post
 /collections,get
 /collections,post
 /collections/{id},put
@@ -36,7 +34,6 @@
 /custom-compliance/{id},delete
 /defenders,get
 /defenders/{id}/upgrade,post
-/defenders/app-embedded,post
 /defenders/download,get
 /defenders/daemonset.yaml,post
 /defenders/fargate.json,post

--- a/api/_topic_map.yml
+++ b/api/_topic_map.yml
@@ -1211,6 +1211,13 @@
     post:
       description: !include ../descriptions/registry/stop_post.md
 
+  /webhook/webhook:
+    delete:
+      description: !include ../descriptions/registry/webhook_webhook_delete.md
+
+    post:
+      description: !include ../descriptions/registry/webhook_webhook_post.md
+
 #
 # /api/v1/scans
 #

--- a/api/descriptions/registry/webhook_webhook_delete.md
+++ b/api/descriptions/registry/webhook_webhook_delete.md
@@ -1,0 +1,3 @@
+Listens for registry updates.
+
+Although this endpoint is supported, no backwards compatibility is offered for it.

--- a/api/descriptions/registry/webhook_webhook_post.md
+++ b/api/descriptions/registry/webhook_webhook_post.md
@@ -1,0 +1,3 @@
+Listens for registry updates.
+
+Although this endpoint is supported, no backwards compatibility is offered for it.

--- a/api/descriptions/settings/license_post.md
+++ b/api/descriptions/settings/license_post.md
@@ -1,5 +1,7 @@
-Sets up your Twistlock license.
+Sets up your Prisma Cloud Compute license.
 Use this endpoint, along with `/api/v1/signup`, as part of the initial set up flow after Twistlock is first installed.
+
+Although this endpoint is supported, no backwards compatibility is offered for it.
 
 The following example curl command uses basic auth to set your license.
 

--- a/api/descriptions/signup/post.md
+++ b/api/descriptions/signup/post.md
@@ -1,5 +1,7 @@
 Creates the initial admin user after Console is first installed.
 
+Although this endpoint is supported, no backwards compatibility is offered for it.
+
 ### cURL Request
 
 The following cURL command creates the initial admin user with the username `admin` and password `password`.


### PR DESCRIPTION
* Refine list of supported endpoints
* Update descriptions for endpoints that are supported, but offer no backwards compatibility:
  * POST /settings/license
  * POST /signup
  * DELETE /registry/webhook/webhook
  * POST /registry/webhook/webhook