### PR TITLE
Update 21.08 release notes.

### DIFF
--- a/rn/release-information/release-notes-21-08.adoc
+++ b/rn/release-information/release-notes-21-08.adoc
@@ -372,6 +372,12 @@ When "Reported results" is configured to show both passed and failed checks, if 
 // #32050
 * In 'Code Repository' scan feature, as we updated to include Github Enterprise Server support, the URL links in the scan results for the existing Github Cloud repositories scans got removed. To get the links active, delete the current Git repository scan scopes and recreate a new one.
 
+// #32739
+* The `/util/twistcli` endpoint for downloading the twistcli binary from the API is missing from the OpenAPI spec file and the documentation.
+This endpoint is supported.
+Work to fix the issue is scheduled.
+
+
 === Deprecated this release
 
 // #23447


### PR DESCRIPTION
Add known limitation for the `/util/twistcli` API endpoint.