### PR TITLE
Update 21.08 release notes

### DIFF
--- a/rn/release-information/release-notes-21-08.adoc
+++ b/rn/release-information/release-notes-21-08.adoc
@@ -399,6 +399,9 @@ Often customers don't have the bandwidth to properly plan and tune runtime defen
 Disabling runtime defense lets customers postpone runtime defense configuration to a more convenient time.
 Runtime defense can be enabled by creating a rule.
 
+* Starting in 21.08, the IaC scan option in twistcli (`twistcli ian`) has been removed.
+Prisma Cloud IaC functionality can still be used directly via the IaC API or the available https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/prisma-cloud-devops-security.html[DevOps plugins].
+
 
 === Upcoming deprecations
 


### PR DESCRIPTION
The iac option has been removed from twistcli. Point customers to how they can use IaC functionality.
