### PR TITLE
Update install_single_container_defender.adoc

### DIFF
--- a/admin_guide/install/install_defender/install_single_container_defender.adoc
+++ b/admin_guide/install/install_defender/install_single_container_defender.adoc
@@ -72,9 +72,6 @@ For example, an AWS EC2 host would have the following name: Ip-171-29-1-244.ec2i
 .. In the second drop-down list (5), select the xref:../../install/defender_types.adoc#[Defender type].
 Both Linux and Windows platforms are supported.
 
-.. In the second drop-down list (5), select the xref:../../install/defender_types.adoc#[Defender type].
-Both Linux and Windows platforms are supported.
-
 .. In the third drop-down list (6), leave the xref:../../access_control/rbac.adoc#_defender_listener_type[listener type] set to *None*.
 
 .. In the final field (7), copy the install command, which is generated according to the options you selected.


### PR DESCRIPTION
Removed lines 74-76 , as they are a duplicate of the wording.  ".. In the second drop-down list (5), select the xref:../../install/defender_types.adoc#[Defender type].
Both Linux and Windows platforms are supported." is stated twice.

## Description
https://docs.paloaltonetworks.com/prisma/prisma-cloud/21-08/prisma-cloud-compute-edition-admin/install/install_defender/install_single_container_defender.html

Section Bullets 5/6 are the same lines, I believe they were copied twice on accident.

## Motivation and Context
In the documentation, the same line is repeated twice. I believe that this may be just a small oversight, and can be remedied by removing one of the entries.
## How Has This Been Tested?
N/a



## Types of changes

Simple documentation edit/cleanup 



## Checklist



- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.

