### PR TITLE
Update 21.08 update 1 release notes

### DIFF
--- a/rn/release-information/release-notes-21-08-update1.adoc
+++ b/rn/release-information/release-notes-21-08-update1.adoc
@@ -78,4 +78,6 @@ Istio 1.11 is supported on all 21.08 releases.
 === Known issues
 
 // #31803
-* Auto-deploy for Host Defender on GCP fails with an authorization error.
+* [SaaS] Auto-deploy for Host Defender on GCP fails with an authorization error.
+This issue is limited to SaaS only.
+Compute Edition (self-hosted) isn't impacted.

--- a/rn/release-information/release-notes-21-08-update1.adoc
+++ b/rn/release-information/release-notes-21-08-update1.adoc
@@ -73,3 +73,9 @@ Integrations are specified when setting up Compute alerts.
 // #32871
 * Validates support for Istio 1.11.
 Istio 1.11 is supported on all 21.08 releases.
+
+
+=== Known issues
+
+// #31803
+* Auto-deploy for Host Defender on GCP fails with an authorization error.


### PR DESCRIPTION
Add known limitation - Auto-deploying Host Defender on GCP on SaaS fails with an auth error
