### PR TITLE
twistcli_scan_IAC is now deprecated.

### DIFF
--- a/admin_guide/tools/twistcli_scan_iac.adoc
+++ b/admin_guide/tools/twistcli_scan_iac.adoc
@@ -1,76 +1,9 @@
 == Scan Infrastructure as Code (IaC) with twistcli
 
-To identify potential issues you can scan content in your IaC templates such as AWS CloudFormation Templates (JSON or YAML format), HashiCorp Terraform templates (HCL format), and Kubernetes App manifests (JSON or YAML format) against a list of https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-policy-reference/configuration-policies/configuration-policies-build-phase.html[IaC policies].
+  This feature was deprecated with the release of 21.08 - https://docs.paloaltonetworks.com/prisma/prisma-cloud/21-08/prisma-cloud-compute-edition-release-notes/release-information/release-notes-21-08.html
 
-With a valid Prisma Cloud Enterprise Edition license, you can use twistcli to scan IaC template files. 
+Instead, please use the API for your scanning or refer to the Prisma Cloud DevOps Security page for other use cases.
 
+Prisma Cloud IAC Scanning API : https://prisma.pan.dev/api/cloud/cspm/iac-scan/
 
-=== Command reference
-
-`twistcli iac scan` -- Scan an IaC file such as AWS CloudFormation template, Terraform template and Kubernetes manifest files against a list of default and custom policies. Prisma Cloud SaaS console connectivity is required for this functionality.
-
-
-=== Synopsis
-
-  twistcli iac scan [OPTIONS] [File]
-
-
-=== Description
-
-The twistcli iac scan function collects all IaC files provided, sends those back to saas service for security assessment, and provides results back. 
-
-
-==== Options
-
-`--addressURL`::
-Complete URL for Console, including the protocol and port.
-Only the HTTPS protocol is supported.
-By default, Console listens to HTTPS on port 8083, although your administrator can configure Console to listen on a different port.
-Defaults to https://127.0.0.1:8083.
-+
-Example: --address https://console.example.com:8083
-
-`-u`, `--user`::
-Username to access Console. If not provided, the TWISTLOCK_USER environment variable will be used if defined, or "admin" is used as the default.
-
-`-p`, `--password`::
-Password for the user specified with -u, --user.
-If not specified on the command-line, the TWISTLOCK_PASSWORD environment variable will be used if defined, or otherwise will prompt for the user’s password before the scan runs.
-
-`--scantype`::
-IaC template type is specified here, and allowed values are cft,k8s,tf011,tf012,tf013
-
-`--assetname`::
-This is identified to a specific scan, and it is used to find the result in Prisma Cloud UI.
-This can be something like project name or team name e.g. payapp project that user can choose and decide. 
-
-`--configfile`::
-Configuration Options can be also specified as a config file.
-More information about config file is available https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/prisma-cloud-devops-security/set-up-your-prisma-cloud-configuration-file-for-iac-scan.html[here].
- 
-`-- Compliance threshold`::
-(Optional flag) a threshold that designates when a scan should fail, it's also called failure criteria in Prisma, it can be either one of the three values Low, Medium and High. High is the default value if no threshold is specified. 
-
-`-- Scan attributes`::
-(optional flag) a comma-separated list of key:value pairs (e.g. cicd-project:payapp, pipeline:staging) to be associated with the scan and seen in Prisma UI
-
-`-- Scan tags`::
-(optional flag) a comma-separated list of key:value pairs (e.g. env:prod, owner:dan) to be associated with the scan. These tags are used for RBAC in Prisma Cloud UI. Also, build alert rules can be configured to choose specific policies in Prisma Cloud UI. 
-
-`-- Policy IDs`::
-(Optional flag) a comma separated list of policy IDs to test against. Policy IDs can be retrieved with this https://api.docs.prismacloud.io/reference#get-policies-v2 [API]
-
-`-- Files`::
-(Optional flag) a comma-separated list of files to scan from the provided archive to twistcli
-
-`-- Folders`::
-(optional flag) a comma-separated list of folders to scan from the provided archive to twistcli
-
-`-- Variable files`::
-(Optional flag) applicable in all scans except k8s, a comma separated list of variable files to consider when scanning
-
-`-- Variables`::
-(Optional flag) applicable in all scans except k8s, a comma separated list of variables to consider when scanning
-
-`-- Output file`::
-(Optional flag) an output file name that will additionally contain the output result (additional to displayed)
+Prisma Cloud DevOps Security : https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/prisma-cloud-devops-security.html

--- a/admin_guide/tools/twistcli_scan_iac.adoc
+++ b/admin_guide/tools/twistcli_scan_iac.adoc
@@ -1,6 +1,6 @@
 == Scan Infrastructure as Code (IaC) with twistcli
 
-  This feature was deprecated with the release of 21.08 - https://docs.paloaltonetworks.com/prisma/prisma-cloud/21-08/prisma-cloud-compute-edition-release-notes/release-information/release-notes-21-08.html
+This feature was deprecated with the release of 21.08 - https://docs.paloaltonetworks.com/prisma/prisma-cloud/21-08/prisma-cloud-compute-edition-release-notes/release-information/release-notes-21-08.html
 
 Instead, please use the API for your scanning or refer to the Prisma Cloud DevOps Security page for other use cases.
 


### PR DESCRIPTION
This feature is deprecated / removed with the recent update see - https://docs.paloaltonetworks.com/prisma/prisma-cloud/21-08/prisma-cloud-compute-edition-release-notes/release-information/release-notes-21-08.html

Because of this, have had customers open cases confused on the proper way to do this.
It appears we can still do this operation by using the API itself.
Suggesting that perhaps instead of have the page above have the info it holds, maybe just have a link to where to go etc.
Not entirely sure if this suggested change is the best method- but I still want to get the ball rolling on this. Thank you!!

