### PR TITLE
Update instructions to reflect that 'Downloads' is now 'Utilities'

### DIFF
--- a/admin_guide/authentication/access_keys.adoc
+++ b/admin_guide/authentication/access_keys.adoc
@@ -128,7 +128,7 @@ After provisioning your key, you can test that it can access the Compute API.
 Both the Jenkins plugin and twistcli wrap the API, so hitting the API directly lets you validate that your key has the proper permissions.
 
 The path to the Compute Console API, whether you interface with it directly (e.g. curl) or indirectly (Jenkins, twistcli) is published in Compute Console itself.
-Get it from *Compute > Manage > System > Downloads*.
+Get it from *Compute > Manage > System > Utilities*.
 
 image::access_keys_path_to_console.png[width=800]
 
@@ -136,7 +136,7 @@ image::access_keys_path_to_console.png[width=800]
 [.procedure]
 . Get the path to your Console.
 
-.. Go to *Compute > Manage > System > Downloads*.
+.. Go to *Compute > Manage > System > Utilities*.
 
 .. Under *Path to Console*, click *Copy*.
 

--- a/admin_guide/install/twistlock_container_images.adoc
+++ b/admin_guide/install/twistlock_container_images.adoc
@@ -12,7 +12,7 @@ You can push the Prisma Cloud images to your own private registry, and manage th
 ifdef::compute_edition[]
 The Console image is delivered as a _.tar.gz_ file in the release tarball.
 endif::compute_edition[]
-The Defender image can be downloaded from Console, under *Manage > System > Downloads*, or from the Prisma Cloud API.
+The Defender image can be downloaded from Console, under *Manage > System > Utilities*, or from the Prisma Cloud API.
 
 There are two different methods for accessing images in the cloud registry:
 

--- a/admin_guide/tools/twistcli.adoc
+++ b/admin_guide/tools/twistcli.adoc
@@ -53,7 +53,7 @@ For the default Kubernetes installation procedure, the Console service is expose
 endif::compute_edition[]
 
 ifdef::prisma_cloud[]
-To get the address for your Console, go to *Compute > Manage > System > Downloads*, and copy the string under *Path to Console*.
+To get the address for your Console, go to *Compute > Manage > System > Utilities*, and copy the string under *Path to Console*.
 endif::prisma_cloud[]
 
 

--- a/admin_guide/tools/twistcli_scan_iac.adoc.orig
+++ b/admin_guide/tools/twistcli_scan_iac.adoc.orig
@@ -43,7 +43,7 @@ Only the HTTPS protocol is supported.
 +
 Example: --address https://us-west1.cloud.twistlock.com/us-3-123456789
 
-To get the address for your Console, go to *Compute > Manage > System > Downloads*, and copy the string under *Path to Console*.
+To get the address for your Console, go to *Compute > Manage > System > Utilities*, and copy the string under *Path to Console*.
 
 `-u`, `--user` [.underline]#`Access Key ID`#::
 _Access Key ID_ to access Prisma Cloud. 

--- a/admin_guide/tools/twistcli_scan_images.adoc
+++ b/admin_guide/tools/twistcli_scan_images.adoc
@@ -60,7 +60,7 @@ ifdef::prisma_cloud[]
 Required.
 URL for Console, including the protocol and port.
 Only the HTTPS protocol is supported.
-To get the address for your Console, go to *Compute > Manage > System > Downloads*, and copy the string under *Path to Console*.
+To get the address for your Console, go to *Compute > Manage > System > Utilities*, and copy the string under *Path to Console*.
 +
 Example: --address \https://us-west1.cloud.twistlock.com/us-3-123456789
 
@@ -679,7 +679,7 @@ You can use your username:password from PC or Access Key / Secret Key created by
 
 . Create an Access Key with desired expiration time. Make sure you keep this secure by downloading or copying for future use.   
 
-. Get Compute Console URL from Compute tab - Manage > System > Downloads. 
+. Get Compute Console URL from Compute tab - Manage > System > Utilities.
 
 . Use Access Key as username and Secret key as password for your twistcli calls
 +

--- a/admin_guide/vulnerability_management/serverless_functions.adoc
+++ b/admin_guide/vulnerability_management/serverless_functions.adoc
@@ -183,7 +183,7 @@ Only the HTTPS protocol is supported.
 +
 Example: --address https://https://us-west1.cloud.twistlock.com/us-3-123456789
 
-To get the address for your Console, go to *Compute > Manage > System > Downloads*, and copy the string under *Path to Console*.
+To get the address for your Console, go to *Compute > Manage > System > Utilities*, and copy the string under *Path to Console*.
 
 `-u`, `--user` [.underline]#`Access Key ID`#::
 _Access Key ID_ to access Prisma Cloud. 

--- a/admin_guide/welcome/nat_gateway_ip_addresses.adoc
+++ b/admin_guide/welcome/nat_gateway_ip_addresses.adoc
@@ -10,7 +10,7 @@ To recognize your Prisma Cloud app stack / Tenant region, check the URL in brows
 Example: https://app3.prismacloud.io/ 
 The "app3" in address indicates your Prisma Cloud tenant region.
 
-To recognize your Compute Console region, find the region in the URL for **Path to Console** under **Manage > System > Downloads** tab in Compute Console.
+To recognize your Compute Console region, find the region in the URL for **Path to Console** under **Manage > System > Utilities** tab in Compute Console.
 
 Example: https://us-west1.cloud.twistlock.com/us-xxxxxx
 The "us-west1" indicates your Compute Console region.

--- a/admin_guide/welcome/product_architecture.adoc
+++ b/admin_guide/welcome/product_architecture.adoc
@@ -80,7 +80,7 @@ It's important to make the distinction between the inner and outer interfaces be
 
 image::prisma_cloud_arch2.png[width=800]
 
-You can find the address of Compute Console in Prisma Cloud under *Compute > Manage > System > Downloads*.
+You can find the address of Compute Console in Prisma Cloud under *Compute > Manage > System > Utilities*.
 The address for Compute Console has the following format:
 
   https://<region>.cloud.twistlock.com/<customer>

--- a/admin_guide/welcome/utilities_and_plugins.adoc
+++ b/admin_guide/welcome/utilities_and_plugins.adoc
@@ -5,7 +5,7 @@ ifdef::compute_edition[]
 They are also bundled with the release tarball you download from the xref:../welcome/releases.adoc[Customer Support Portal]
 endif::compute_edition[]
 
-To download the utilities from Prisma Cloud Console, go to *Manage > System > Downloads*.
+To download the utilities from Prisma Cloud Console, go to *Manage > System > Utilities*.
 From there, you can download:
 
 * Jenkins plugin.

--- a/api/descriptions/util/osx_twistcli_get.md
+++ b/api/descriptions/util/osx_twistcli_get.md
@@ -1,6 +1,6 @@
 Downloads the twistcli binary executable for MacOS platforms.
 
-This endpoint maps to the **MacOS platform** hyperlink in **Manage > System > Downloads** in the Console UI.
+This endpoint maps to the **MacOS platform** hyperlink in **Manage > System > Utilities** in the Console UI.
 
 ### cURL Request
 

--- a/api/descriptions/util/twistcli_get.md
+++ b/api/descriptions/util/twistcli_get.md
@@ -1,6 +1,6 @@
 Downloads the twistcli binary executable for Linux platforms.
 
-This endpoint maps to the **Linux platform** hyperlink in **Manage > System > Downloads** in the Console UI.
+This endpoint maps to the **Linux platform** hyperlink in **Manage > System > Utilities** in the Console UI.
 
 ### cURL Request
 

--- a/api/descriptions/util/windows_twistcli_get.md
+++ b/api/descriptions/util/windows_twistcli_get.md
@@ -1,6 +1,6 @@
 Downloads the twistcli binary executable for Windows platforms.
 
-This endpoint maps to the **Windows platform** hyperlink in **Manage > System > Downloads** in the Console UI.
+This endpoint maps to the **Windows platform** hyperlink in **Manage > System > Utilities** in the Console UI.
 
 ### cURL Request
 


### PR DESCRIPTION
We renamed the Downloads tab to Utilities.  This is an update to replace it in the docs, in several places.