### PR TITLE
update install_defender_gcp_marketplace.adoc

### DIFF
--- a/admin_guide/install/install_defender/install_defender_gcp_marketplace.adoc
+++ b/admin_guide/install/install_defender/install_defender_gcp_marketplace.adoc
@@ -8,7 +8,7 @@ You need access to a Prisma Cloud SaaS Console.
 You can sign up for a free trial of Prisma Cloud on the Google Cloud Marketplace.
 
 [.procedure]
-. Find Prisma Cloud Defender in the GCP Marketplace.
+. Find Prisma Cloud - Kubernetes Security Defender in the GCP Marketplace.
 Click Configure.
 +
 image::gcp1.png[width=600]


### PR DESCRIPTION
The image is outdated for this, as well as the search query term. To find the correct application you must search Prisma Cloud - Kubernetes Security Defender.
None of the other options show the "configure" button as the documentation suggests.

I will also make a PR for the new graphic to use here shortly.

