### PR TITLE
updated to remove confusion on supported tools

### DIFF
--- a/admin_guide/secrets/secrets_manager.adoc
+++ b/admin_guide/secrets/secrets_manager.adoc
@@ -1,7 +1,7 @@
 == Secrets manager
 
 Containers often require sensitive information, such as passwords, SSH keys, encryption keys, and so on.
-You can integrate Prisma Cloud with HashiCorp Vault or CyberArk Enterprise Password Vault to securely distribute secrets from those stores to the containers that need them.
+You can integrate Prisma Cloud with many common Secrets Management Platforms to securely distribute secrets from those stores to the containers that need them.
 
 Enterprise secret stores reduce the risk of data breaches that could occur when sensitive information is littered across an organization, often in places where they should not be, such as email inboxes, source code repositories, developer workstations, and Dropbox.
 Secret stores provide a central and secure location for managing and distributing secrets to the apps that need them.
@@ -42,7 +42,7 @@ Defender starts the container using the Docker API, which is exposed through the
 
 The Prisma Cloud secrets manager has the following capabilities:
 
-* Supports integration with HashiCorp Vault and CyberArk Enterprise Password Vault.
+* Supports integration with common Secrets Management platforms.
 * Manages the distribution of secrets from the secret store to your containers through policies.
 In Console, you create the rules that control which secrets get injected into which containers.
 * Injects secrets into containers as either environment variables or files.

--- a/admin_guide/secrets/secrets_manager.adoc
+++ b/admin_guide/secrets/secrets_manager.adoc
@@ -1,7 +1,7 @@
 == Secrets manager
 
 Containers often require sensitive information, such as passwords, SSH keys, encryption keys, and so on.
-You can integrate Prisma Cloud with many common Secrets Management Platforms to securely distribute secrets from those stores to the containers that need them.
+You can integrate Prisma Cloud with many common secrets management platforms to securely distribute secrets from those stores to the containers that need them.
 
 Enterprise secret stores reduce the risk of data breaches that could occur when sensitive information is littered across an organization, often in places where they should not be, such as email inboxes, source code repositories, developer workstations, and Dropbox.
 Secret stores provide a central and secure location for managing and distributing secrets to the apps that need them.
@@ -42,7 +42,7 @@ Defender starts the container using the Docker API, which is exposed through the
 
 The Prisma Cloud secrets manager has the following capabilities:
 
-* Supports integration with common Secrets Management platforms.
+* Supports integration with common secrets management platforms.
 * Manages the distribution of secrets from the secret store to your containers through policies.
 In Console, you create the rules that control which secrets get injected into which containers.
 * Injects secrets into containers as either environment variables or files.


### PR DESCRIPTION
Reworded to be more generic and leave secrets integrations to the more detailed "Integrate with a secrets store" page.  The main page made it sound like we only supported 2 out of the current 5 options.

