### PR TITLE
Update VMware Tanzu Kubernetes Grid (TKG) deployment doc

### DIFF
--- a/admin_guide/install/install_vmware_tkg.adoc
+++ b/admin_guide/install/install_vmware_tkg.adoc
@@ -34,12 +34,7 @@ ifdef::compute_edition[]
 endif::compute_edition[]
 
 * Prisma Cloud Defender requires elevated privileges.
-Ensure that the following permissions are set in your TKG cluster:
-
-** Set Privileged Containers to true (enabled).
-
-** Set DenyEscalatingExec to false (disabled).
-After Prisma Cloud is installed, you can utilize it to deny other privileged containers from starting and deny escalation of privileges.
+Ensure that the _Set Privileged Containers_ permission is set to true (enabled) in your TKG cluster.
 
 * The nodes in your cluster can reach Prisma Cloud's cloud registry (registry-auth.twistlock.com).
 


### PR DESCRIPTION
Removed the DenyEscalatingExec reference as it is deprecated starting k8s 1.18

