### PR TITLE
Update vm_image_scanning.adoc

### DIFF
--- a/admin_guide/vulnerability_management/vm_image_scanning.adoc
+++ b/admin_guide/vulnerability_management/vm_image_scanning.adoc
@@ -9,7 +9,6 @@ RHCOS uses Ignition.
 * Images that use paravirtualization.
 * Images that only support old TLS protocols (less than TLS 1.1) for utilities such as curl.
 For example, Ubuntu 12.10.
-* Encrypted images.
 
 ifdef::prisma_cloud[]
 // #20384: To be addressed in Galileo.


### PR DESCRIPTION
removed the bullet that stated we do not scan encrypted AMIs ( this was a new feature in 21.08)

