### PR TITLE
Update upgrade_process_saas.adoc

### DIFF
--- a/admin_guide/upgrade/upgrade_process_saas.adoc
+++ b/admin_guide/upgrade/upgrade_process_saas.adoc
@@ -6,7 +6,7 @@ For email notifications about Prisma Cloud Compute's maintenance schedules and u
 === Console 
 
 Palo Alto Networks periodically upgrades your Prisma Cloud Compute Console.
-Detailed upgrade plans for each release are always published on our https://docs.twistlock.com/docs/enterprise_edition/welcome/announcements.html[announcements page].
+The changes for each release are always published in the https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-release-notes/prisma-cloud-compute-release-information.html[Release Notes].
 Ensure that you have read through all 'Breaking Changes' in release notes for each major release, for any action items from the users.
 
 The currently installed version of Console is displayed in the bell menu.


### PR DESCRIPTION
replaced the link to the new Prisma Cloud Release Notes

