### PR TITLE
Update runtime_defense_containers.adoc

### DIFF
--- a/admin_guide/runtime_defense/runtime_defense_containers.adoc
+++ b/admin_guide/runtime_defense/runtime_defense_containers.adoc
@@ -23,9 +23,9 @@ Click on the image to view the model.
 
 There is a 1:1 relationship between models and images; every image has a model and every model applies to a single unique image.
 For each image, a unique model is created and mapped to the image digest.
-So, even if there are multiple images with the same tags, Prisma Cloud will create unique models for each.
+So, even if there are multiple images with the same tags, Prisma Cloud creates a unique model for each image.
 
-Models are built from both static analysis (such as building a hashed process map based on parsing an init script in a Dockerfile ENTRYPOINT) and dynamic behavioral analysis (such as observing actual process activity during early runtime of the container).
+Models are built from both static analysis, such as building a hashed process map based on parsing an init script in a Dockerfile ENTRYPOINT),  and from dynamic behavioral analysis, such as observing actual process activity during early runtime of the container.
 Models can be in one of 3 modes: Active, Archived, or Learning.
 
 image::runtime_defense_734302.png[width=800]
@@ -70,12 +70,12 @@ Prisma Cloud automatically detects when new images are added anywhere in the env
 
 image::runtime_defense_792723.png[width=800]
 
-* Relearn: You can relearn an existing model by clicking the *Relearn* button in the *Actions* menu.
-This is an additive process, so any existing static and behavioral modeling remains in place.
+* Extend Learning: You can relearn an existing model by clicking the *Extend Learning* option in the *Actions* menu.
+This is an additive process, and any existing static and behavioral modeling remains in place.
 
-* Manual Learning: Users can manually alter the duration of learning at any time by starting and stopping the *Manual Learning* option in the *Actions* menu.
+* Manual Relearning: You can manually alter the duration of learning at any time by starting and stopping the *Manual Relearning* option in the *Actions* menu.
 This should be done with discretion because the model may or may not complete within the time period due to manual interruption.
-There is no time limit for manual learning and depends on user's choice.
+There is no time limit for manual relearning and depends on user's choice.
 
 
 === Active mode


### PR DESCRIPTION
Fixed the labels for Relearn and Manual Learning to match the current UI.
Still need to address the question: 'manual relearning' the text itself is unclear in meaning : what exactly does this do ?

