### PR TITLE
Reachable from the internet risk factor clarification

### DIFF
--- a/admin_guide/vulnerability_management/vuln_explorer.adoc
+++ b/admin_guide/vulnerability_management/vuln_explorer.adoc
@@ -132,7 +132,7 @@ Vulnerability is remotely exploitable.
 The vulnerable component is bound to the network, and the attacker's path is through the network.
 
 * *Reachable from the internet* --
-Vulnerability exists in a container exposed to the internet.
+Vulnerability exists in a container exposed to the internet. The detection of this risk factor requires that CNNF will be enabled and network objects will be defined for external sources under *Radar > Settings*. Then, if a connection is established between the defined external source and the container, the container is identified as reachable from the internet.
 
 * *Listening ports* --
 Vulnerability exists in a container that is listening on network ports.


### PR DESCRIPTION
Following this bug https://spring.paloaltonetworks.com/twistlock/twistlock/issues/32544

Clarify that the detection of the "Reachable from the internet" risk factor depends on CNNF.