### PR TITLE
Clarify WAAS "server" benchmark is WAAS-protected nginx

### DIFF
--- a/compute/admin_guide/deployment_patterns/performance_planning.adoc
+++ b/compute/admin_guide/deployment_patterns/performance_planning.adoc
@@ -149,9 +149,9 @@ Benchmark target servers were run on AWS EC2 instances running Ubuntu Server 18.
 |===
 |Instance type|Environment|Compared servers|Versions
 
-|t2.large|Docker|Nginx vs WAAS|Nginx/1.19.0
-|t2.large|Host|Nginx vs WAAS|Nginx/1.14.0
-|t2.large|Kubernetes|Nginx vs WAAS|Nginx/1.17.10
+|t2.large|Docker|Nginx vs WAAS-protected Nginx|Nginx/1.19.0
+|t2.large|Host|Nginx vs WAAS-protected Nginx|Nginx/1.14.0
+|t2.large|Kubernetes|Nginx vs WAAS-protected Nginx|Nginx/1.17.10
 |===
 
 ===== Benchmarking client
@@ -212,7 +212,7 @@ The following table details request average *overhead* (in milliseconds):
  <.^|POST w/ 5KB body ^.^|43 ^.^|421 ^.^|1,013 ^.^|2,005 ^.^|3,557
 |===
 
-NOTE: WAAS response time can be faster than origin-server response time when attacks are blocked and not forwarded to the origin server.
+NOTE: Negative numbers indicate a performance improvement.  WAAS response time can be faster than origin-server response time when attacks are blocked and not forwarded to the origin server.
 
 ===== Load testing
 


### PR DESCRIPTION
This commit updates the WAAS benchmark text to clarify that the "servers" compared are both nginx, just one of them has WAAS enabled.  It also spells out that negative "overhead" values indicate a speed-up, rather than assuming the reader knows that.