### PR TITLE
Update the URL for downloading apoctl

### DIFF
--- a/cns/saas/admin_guide/start/install-apoctl.adoc
+++ b/cns/saas/admin_guide/start/install-apoctl.adoc
@@ -36,7 +36,7 @@ Any TLS-intercepting https://tools.ietf.org/html/rfc3234[middleboxes] must be co
 [.procedure]
 . Download the executable appropriate to your platform.
 +
-The URL format is https://download.aporeto.com/prismacloud/[appstack]/apoctl/[ darwin | windows | linux ]/apoctl
+The URL format is `+https://download.aporeto.com/prismacloud/[appstack]/apoctl/[ darwin | windows | linux ]/apoctl+`
 where you must replace [appstack] with the location of your instance of Prisma Cloud. 
 The URL for Prisma Cloud varies depending on the region and cluster on which your tenant is deployed. 
 For example, 

--- a/cns/saas/admin_guide/start/install-apoctl.adoc
+++ b/cns/saas/admin_guide/start/install-apoctl.adoc
@@ -36,12 +36,19 @@ Any TLS-intercepting https://tools.ietf.org/html/rfc3234[middleboxes] must be co
 [.procedure]
 . Download the executable appropriate to your platform.
 +
+The URL format is https://download.aporeto.com/prismacloud/[appstack]/apoctl/[ darwin | windows | linux ]/apoctl
+where you must replace [appstack] with the location of your instance of Prisma Cloud. The URL for Prisma Cloud varies depending on the region and cluster on which your tenant is deployed. 
+For example, 
+----
+https://download.aporeto.com/prismacloud/app3/darwin/apoctl
+----
++
 macOS
 +
 [,console,subs="+attributes"]
 ----
 sudo curl -o /usr/local/bin/apoctl \
-  {download-url}{version}/apoctl/darwin/apoctl && \
+ https://download.aporeto.com/prismacloud/<your_appstack>/darwin/apoctl && \
 sudo chmod 755 /usr/local/bin/apoctl
 ----
 +
@@ -50,7 +57,7 @@ Linux
 [,console,subs="+attributes"]
 ----
 sudo curl -o /usr/local/bin/apoctl \
-  {download-url}{version}/apoctl/linux/apoctl && \
+  https://download.aporeto.com/prismacloud/<your_appstack>/linux/apoctl && \
 sudo chmod 755 /usr/local/bin/apoctl
 ----
 +
@@ -58,7 +65,7 @@ Windows
 +
 [,powershell]
 ----
-curl {download-url}{version}/apoctl/windows/apoctl.msi -o apoctl.msi; `
+curl https://download.aporeto.com/prismacloud/<your_appstack>/windows/apoctl.msi -o apoctl.msi; `
 if ($?) {. .\apoctl.msi /quiet}
 if ($?) {$env:PATH+="C:\Program Files\Apoctl;"}
 ----

--- a/cns/saas/admin_guide/start/install-apoctl.adoc
+++ b/cns/saas/admin_guide/start/install-apoctl.adoc
@@ -37,8 +37,10 @@ Any TLS-intercepting https://tools.ietf.org/html/rfc3234[middleboxes] must be co
 . Download the executable appropriate to your platform.
 +
 The URL format is https://download.aporeto.com/prismacloud/[appstack]/apoctl/[ darwin | windows | linux ]/apoctl
-where you must replace [appstack] with the location of your instance of Prisma Cloud. The URL for Prisma Cloud varies depending on the region and cluster on which your tenant is deployed. 
+where you must replace [appstack] with the location of your instance of Prisma Cloud. 
+The URL for Prisma Cloud varies depending on the region and cluster on which your tenant is deployed. 
 For example, 
++
 ----
 https://download.aporeto.com/prismacloud/app3/darwin/apoctl
 ----


### PR DESCRIPTION
the format is https://download.aporeto.com/prismacloud/[appstack]/apoctl/[ darwin | windows | linux ]/apoctl

instead of https://download.aporeto.com{version}/apoctl/darwin/apoctl
it’ll just be https://download.aporeto.com/prismacloud/**app**/darwin/apoctl 