### PR TITLE
Update system_requirements.adoc

### DIFF
--- a/compute/admin_guide/install/system_requirements.adoc
+++ b/compute/admin_guide/install/system_requirements.adoc
@@ -254,7 +254,7 @@ GKE 1.20.9 (Docker 20.10.3 and containerd 1.4.4)
 GKE 1.19.3 (containerd 1.4.6)
 
 |OpenShift
-|3.11, 4.6, 4.7, 4.8 (4.8.0 to 4.8.2 only), 4.9.0
+|3.11 - docker version only, 4.6, 4.7, 4.8 (4.8.0 to 4.8.2 only), 4.9.0
 
 |VMware Tanzu Application Service - TAS
 |v2.9, v2.10, v2.11


### PR DESCRIPTION
stating that openshift v3.11 is supported for docker only

