### PR TITLE
Missing Incident Types in documentation

### DIFF
--- a/compute/admin_guide/runtime_defense/incident_types/Missing types in document
+++ b/compute/admin_guide/runtime_defense/incident_types/Missing types in document
@@ -1,0 +1,10 @@
+#These three types are not in our public documentation
+
+Hijacked Process:
+Hijacked Process incident indicates that an allowed process has been used in ways that are inconsistent with its expected behavior. This type of incident could be a sign that a process has been used to compromise a container
+
+Data exfiltration:
+Data exfiltration is the unauthorized transfer of data from one system to another, these incidents are triggered when a pattern of audits indicate attempts to move data to an external location. for example: High rate of dns query events, reporting aggregation started in a container, DNS resolution of suspicious name (www.<WEBSITE_NAME>.com).
+
+Cloud Provider
+Cloud Provider incident indicates attempts to abuse a provider's service to extract sensitive information, for example: Container A queried provider API at <IP_ADDRESS>.


### PR DESCRIPTION
These three types are not in our public documentation:

Hijacked Process:
Data exfiltration:
Cloud Provider