### PR TITLE
Update note for "JOB_NAME" environment variable

### DIFF
--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -177,6 +177,10 @@ If it fails, for whatever reason, you want to fail everything because there is a
 
 To view scan reports in Console, go to *Monitor > Vulnerabilities > Images > CI* or *Monitor > Compliance > Images > CI*.
 
+The scan reports includes the image vulnerabilities, compliance issues, layers, process info, package info, and labels.
+
+When scanning images in the CI pipeline with twistcli or the xref:../continuous_integration/jenkins_plugin.adoc[Jenkins plugin], Prisma Cloud collects the environment variable `JOB_NAME` from the machine the scan ran on, and adds it as a label to the scan report.
+
 You can also retrieve scan reports in JSON format using the Prisma Cloud API, see the <<_api, API>> section.
 
 
@@ -188,7 +192,7 @@ The twistcli tool can output scan results to several places:
 * File.
 Scan results are saved in JSON format.
 * Console.
-Scan results can be viewed under *Monitor > Vulnerabilities > Images > CI*.
+Scan results can be viewed under *Monitor > Vulnerabilities > Images > CI* or *Monitor > Compliance > Images > CI*.
 
 By passing certain flags, you can adjust how the twistcli scan output looks and where it goes.
 By default, twistcli writes scan results to stdout and sends the results to Console.


### PR DESCRIPTION
Added note regarding collecting the "JOB_NAME" environment variable.

Using this environment variable was suggested to Daimler as a workaround for https://paloaltonetworkscloud.aha.io/ideas/ideas/PANW-I-2740

