### PR TITLE
Update system_requirements.adoc

### DIFF
--- a/compute/admin_guide/install/system_requirements.adoc
+++ b/compute/admin_guide/install/system_requirements.adoc
@@ -256,7 +256,7 @@ GKE 1.19.3 (containerd 1.4.6)
 GKE Autopilot Rapid channel (containerd)
 
 |OpenShift
-|3.11 - docker version only, 4.6, 4.7, 4.8 (4.8.0 to 4.8.2 only), 4.9.0
+|3.11 - docker version only, 4.6, 4.7, 4.8, 4.9.0
 
 |VMware Tanzu Application Service - TAS
 |v2.9, v2.10, v2.11


### PR DESCRIPTION
Removing  Openshift versions for (4.8.0 to 4.8.2 only). We fixed this issue in Iverson update 2 https://spring.paloaltonetworks.com/twistlock/twistlock/issues/33004

cc @MayaShani @iansk