### PR TITLE
Fix PCSUP-7410

### DIFF
--- a/compute/admin_guide/compliance/custom_compliance_checks.adoc
+++ b/compute/admin_guide/compliance/custom_compliance_checks.adoc
@@ -17,9 +17,8 @@ For Windows container images, the default shell is cmd.exe.
 //From: https://github.com/twistlock/twistlock/issues/12805
 
 If you want to use a specific shell, or if your default shell is in a non-standard location, use the shebang interpreter directive at the top of your compliance check to specify the path to the executable.
-For example, the following directive specifies that the Linux Bourne-again (bash) shell should parse and interpret the compliance check.
 
-  #!/bin/bash
+For example, `#!/bin/bash` specifies that the Linux Bourne-again (bash) shell should parse and interpret the compliance check.
 ====
 
 For containers, Defender runs the compliance checks inside a restricted sandboxed container instantiated from the image being scanned, thus avoiding the unnecessary risk associated with running arbitrary code.


### PR DESCRIPTION
There's currently an issue with the HTML transform, which doesn't properly close the div for the note when a note contains a codeblock element.

Refactor the note so that it doesn't use a codeblock, and so that the page renders properly.

