### PR TITLE
Remove 'step 4' for v19.03 Kubernetes upgrade procedures

### DIFF
--- a/compute/admin_guide/upgrade/upgrade_kubernetes.adoc
+++ b/compute/admin_guide/upgrade/upgrade_kubernetes.adoc
@@ -33,14 +33,6 @@ The following example command generates a YAML configuration file for the defaul
 
   $ <PLATFORM>/twistcli console export kubernetes --service-type LoadBalancer
 
-. If you're upgrading from 19.03, then you must first delete the old ReplicationController.
-Starting with 19.07, Prisma Cloud Console is managed by a Deployment controller.
-+
-This is a one time step only.
-After upgrading to 19.07, you no longer need to manually delete the ReplicationContoller when upgrading to newer versions of Prisma Cloud.
-+
-  $ kubectl delete rc twistlock-console -n twistlock
-
 . Update the Prisma Cloud objects.
 
   $ kubectl apply -f twistlock_console.yaml


### PR DESCRIPTION
Removed out dated upgrade procedure from version 19.03