### PR TITLE
Update install_openshift_3_11.adoc

### DIFF
--- a/compute/admin_guide/install/install_openshift_3_11.adoc
+++ b/compute/admin_guide/install/install_openshift_3_11.adoc
@@ -1,4 +1,4 @@
-== OpenShift
+== OpenShift 3.11
 // Not included in the book as of Nov 9,2021
 
 ifdef::compute_edition[]


### PR DESCRIPTION
Inside the documentation on line there are two Openshift entries in the TOC without a differentiator in the TOC heading. I am proposing we add 3.11 for this heading to distinguish it from the Openshift 4 installation page.

