### PR TITLE
Update install_openshift_4.adoc

### DIFF
--- a/compute/admin_guide/install/install_openshift_4.adoc
+++ b/compute/admin_guide/install/install_openshift_4.adoc
@@ -1,4 +1,4 @@
-== OpenShift
+== OpenShift 4
 
 
 ifdef::compute_edition[]


### PR DESCRIPTION
In the TOC currently for Install, there are two headings for Openshift with no differentiator between them. I am proposing we change this pages heading to Openshift 4 to make it readily apparent to customers. I had a POV customer complain about the lack of differentiators.

