### PR TITLE
Update runtime_audits.adoc

### DIFF
--- a/compute/admin_guide/runtime_defense/runtime_audits.adoc
+++ b/compute/admin_guide/runtime_defense/runtime_audits.adoc
@@ -489,7 +489,7 @@ Hosts
 |Indicates that an ELF file, that is not part of the runtime model, was modified. 
 
 * This detection works automatically when using a Container runtime model.
-* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Monitor > Runtime > Container policy* tab. 
+* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Defend > Runtime > Container policy* tab. 
 
 |<process name> changed the binary <file path>
 |
@@ -499,7 +499,7 @@ Hosts
 |Indicates that a file containing sensitive key material, that is not part of the runtime model, was written.
 
 * This detection works automatically when using a Container runtime model.
-* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Monitor > Runtime > Container policy* tab. 
+* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Defend > Runtime > Container policy* tab. 
 
 |<process name> created a key file at <file path>
 |
@@ -510,7 +510,7 @@ Hosts
 
 * This detection works automatically when using a Container runtime model.
 * For Serverless, this works when adding the path to the *Denied & fallback* list under File System.
-* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Monitor > Runtime > Container policy* tab. 
+* To disable this detection, disable the *Enable automatic runtime learning* toggle under the *Defend > Runtime > Container policy* tab. 
 
 |* Container: <process name> wrote suspicious file to <file path>
 * Serverless: <process name> access a suspicious path of <file path>


### PR DESCRIPTION
Fixed the path for Enable automatic runtime learning.
Was "Monitor > Runtime > Container policy”, should be “Defend > Runtime > Container policy”.

