### PR TITLE
Update troubleshoot_vuln_detection.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/troubleshoot_vuln_detection.adoc
+++ b/compute/admin_guide/vulnerability_management/troubleshoot_vuln_detection.adoc
@@ -176,7 +176,7 @@ If you found the package and the vulnerable version in image but have questions 
 
 Navigate to *Monitor > Vulnerabilities > CVE Viewer*, type the CVE ID and verify the source matching OS of your image, or look for the reference with empty Distro and Release if it’s a specific language library.
 
-image::troubleshooting_scan_reports_cve_viewer.png[width=900]
+image::troubleshooting_scan_reports_cve_viewer.png[width=700]
 
 You can then directly search vendor feeds to confirm CVE’s authenticity.
 For OS packages, the relevant vendor site should be consulted.
@@ -276,7 +276,7 @@ CVEs with the status “affected” are CVEs that don’t have a fix yet, and th
 Some other vulnerability scanners don’t show them, but these are not false positives.
 You can also decide not to show vulnerabilities with no fix - go to Defend > Vulnerabilities > edit your desired rule > Advanced settings > turn on the toggle “Apply rule when vendor fixes are available”.
 
-image::troubleshooting_scan_reports_vendor_fixes.png[width=900]
+image::troubleshooting_scan_reports_vendor_fixes.png[width=600]
 
 
 ==== I see a lot of low severity CVEs. What are these? Are they false positives?
@@ -294,6 +294,10 @@ image::troubleshooting_scan_reports_unactionable_vulns.png[width=600]
 For known vulnerabilities with a CVE, we rely on the most authoritative source - for OS packages (packages that are maintained by the OS vendor, marked as type “package” in Compute), the CVE details are taken from the specific vendor feed.
 For other CVEs, the information is taken from official sources like NVD and vendor specific Security Advisories.
 For new vulnerabilities missing analysis or undocumented vulnerabilities (such as PRISMA-IDs), we rely on severity determined by our researchers.
+
+==== Do all CVEs reported by Prisma Cloud rely on information from NVD? 
+
+The National Vulnerability Database (NVD) is one of the major sources on which the Intelligence Stream relies or accurate CVE information. In addition to using NVD and other vendor sources, Prisma Cloud security researchers analyze vulnerabilities on a daily basis. In case we find any discrepancies between our analysis to that of NVD or any other vendor, we partner with them to correct any missing or inaccurate information. We strive to contribute to the security of the open-source community.
 
 
 ==== I see on the Red Hat security page that a CVE affects my OS release, but it doesn’t show up in Prisma’s scan. What happened?


### PR DESCRIPTION
added info on Do all CVEs reported by Prisma rely on information from NVD?

