### PR TITLE
Removed note for Executable File Access audit

### DIFF
--- a/compute/admin_guide/runtime_defense/runtime_audits.adoc
+++ b/compute/admin_guide/runtime_defense/runtime_audits.adoc
@@ -476,7 +476,7 @@ Hosts
 Hosts
 
 |Executable File Access
-|Indicates that an executable file was written. Processes that are known to write binaries, such as “cp” and “mv”, are excluded. 
+|Indicates that an executable file was written. 
 
 * Enable and disable this detection via the *Changes to binaries and certificates* toggle, under the Runtime rule File system tab.
 * To ignore such a detection for a known and allowed process, create a Runtime custom rule that allows these file changes by a specific process 


### PR DESCRIPTION
Removed "Processes that are known to write binaries, such as “cp” and “mv”, are excluded." from the description of the "Executable File Access" audit.

See https://spring.paloaltonetworks.com/twistlock/twistlock/issues/36585

