### PR TITLE
Update vm_image_scanning.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
@@ -55,7 +55,8 @@ To restrict permissions for creating and deleting resources, you can use conditi
 
 * Access from the VPC to the Prisma Cloud Compute Console. 
 +
-For the VMs to send scan results back to the Console, the API communication port must be allowed. The default port is 8083.
+For the VMs to send scan results back to the Console, the default port used for communication is 8084. 
+If you use a different port for enabling Defender to Console communication, make sure that the port is allowed access. Note that this port is used for communication although Defenders are not used for VM image scanning.
 
 
 === Azure

--- a/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
@@ -53,7 +53,9 @@ Prisma Cloud requires the permissions listed above for VM image scanning.
 To restrict permissions for creating and deleting resources, you can use conditional clauses in AWS IAM policy for the security groups and instances that have the prefix "twistlock-scan".
 ====
 
-* A default VPC is required, and access from the default VPC to Console via the port used for Defender to Console communication must be allowed to enable Defenders on VMs created by Console to send scan results back.
+* Access from the VPC to the Prisma Cloud Compute Console. 
++
+For the VMs to send scan results back to the Console, the API communication port must be allowed. The default port is 8083.
 
 
 === Azure
@@ -158,7 +160,7 @@ The service agent has these permissions by default since it used these permissio
 
 === Deployment
 
-VM image scanning is handled by the Console. The Prisma Cloud Console scans a VM image by creating a VM instance which is running the VM image to be scanned.
+VM image scanning is handled by the Console and it does not require Defenders. The Prisma Cloud Console scans a VM image by creating a VM instance which is running the VM image to be scanned.
 When you configure Prisma Cloud to scan VM images, you can define the number of scanners to use. Defining more than one scanner means that the Console will create a number of VM instances to scan multiple VM images simultaneously.
 For scanning large numbers of VM images, increase the number of scanners to improve throughput and reduce scan time.
 


### PR DESCRIPTION
Updated to delete 
Access from the default VPC to Console via the port used for Defender to Console communication must be allowed to enable Defenders on VMs created by Console to send scan results back
and clarify that we use the API port

