### PR TITLE
update log_rotation.adoc

### DIFF
--- a/compute/admin_guide/audit/log_rotation.adoc
+++ b/compute/admin_guide/audit/log_rotation.adoc
@@ -21,9 +21,9 @@ It is configured as follows:
 
 [.section]
 === Console
-
+ifdef::compute_edition[]
 The default path for Console's log file is _/var/lib/twistlock/log/console.log_.
-
+endif::compute_edition[]
 It is configured as follows:
 
 * Truncate the original log file in place after creating a copy, instead of moving the old log file. (`copytruncate`)


### PR DESCRIPTION
added annotation as the console log path is only available in self-hosted

