### PR TITLE
Update install_windows.adoc

### DIFF
--- a/compute/admin_guide/install/install_windows.adoc
+++ b/compute/admin_guide/install/install_windows.adoc
@@ -79,7 +79,7 @@ h|WAAS
 
 |===
 
-Windows Defenders support xref:../compliance/windows.adoc[Windows compliance checks for hosts] and xref:../compliance/custom_compliance_checks.adoc[custom compliance checks].
+Windows Host Defenders support xref:../compliance/windows.adoc[Windows compliance checks for hosts].  Only Windows Container Defenders for Windows based containers support xref:../compliance/custom_compliance_checks.adoc[custom compliance checks].
 
 //NOTE: Windows containers support a block action for runtime defense but do not support a block action for vulnerability and compliance checks.
 

--- a/compute/admin_guide/install/install_windows.adoc
+++ b/compute/admin_guide/install/install_windows.adoc
@@ -79,7 +79,8 @@ h|WAAS
 
 |===
 
-Windows Host Defenders support xref:../compliance/windows.adoc[Windows compliance checks for hosts].  Only Windows Container Defenders for Windows based containers support xref:../compliance/custom_compliance_checks.adoc[custom compliance checks].
+Windows Host Defenders support xref:../compliance/windows.adoc[Windows compliance checks for hosts].
+Only Windows Container Defenders for Windows based containers support xref:../compliance/custom_compliance_checks.adoc[custom compliance checks].
 
 //NOTE: Windows containers support a block action for runtime defense but do not support a block action for vulnerability and compliance checks.
 


### PR DESCRIPTION
This PR is to change the language around Windows Host Defender support for custom compliance.  Custom Compliance checks are not supported with Windows Host Defender.  It is only supported for Windows Container Defender for Windows based containers.  