### PR TITLE
Added note for internal fields

### DIFF
--- a/api/descriptions/images/get.md
+++ b/api/descriptions/images/get.md
@@ -2,6 +2,8 @@ Retrieves image scan reports.
 
 This endpoint maps to the image table in **Monitor > Compliance > Images > Deployed** in the Console UI.
 
+NOTE: The `image` object of the response was created for internal use of Prisma Cloud Compute for image scanning and analysis. Therefore, its inner fields are not saved in the database and will return empty in the endpoint response. You can get some of its values, such as `labels` and `history`, from the main structure of the response.
+
 ### cURL Request
 
 Refer to the following cURL command that retrieves a compact scan report for all images:


### PR DESCRIPTION
Added a note explaining that the "image" object is for internal use and will return empty.

