### PR TITLE
Update install_rasp_defender.adoc

### DIFF
--- a/compute/admin_guide/install/install_defender/install_rasp_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_rasp_defender.adoc
@@ -57,8 +57,6 @@ Embed App-Embedded Defender into a container image from Console's UI.
 [.procedure]
 . Open Console, and go to *Manage > Defenders > Deploy*.
 
-. In the first drop-down list, select the DNS name or IP address that App-Embedded Defender uses to connect to Console.
-
 . In the second drop-down list, select the App-Embedded Defender type.
 
 . In *Deployment Type*, select *Dockerfile*.


### PR DESCRIPTION
In Enterprise version we can't select the console url, so this step may confuse. I believe it is better to delete this step.

