### PR TITLE
fixed the camelcase in filename

### DIFF
--- a/code-security/admin_guide/book.yml
+++ b/code-security/admin_guide/book.yml
@@ -73,11 +73,11 @@ topics:
   - name: Add GitLab to Prisma Cloud Code Security
     file: add-gitlab.adoc
   - name: Connect IntelliJ with Prisma Cloud Code Security
-    file: Connect-intellij.adoc
+    file: connect-intellij.adoc
   - name: Add Jenkins to Prisma Cloud Code Security
     file: add-jenkins.adoc
   - name: Connect VScode with Prisma Cloud Code Security
-    file: Connect-vscode.adoc
+    file: connect-vscode.adoc
 - name: Set Up Developer Access for Code Security
   file: setup-developer-access.adoc
 ---


### PR DESCRIPTION
VS Code and IntelliJ topics used "Connect" instead of "connect"

