### PR TITLE
Add Detail to ECR Registry URL Step

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/scan_ecr.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/scan_ecr.adoc
@@ -48,7 +48,7 @@ The *AmazonEC2ContainerRegistryReadOnly* permissions policy is currently defined
 
 .. In *Version*, select *Amazon EC2 Container Registry*.
 
-.. In *Registry*, enter the URL for the registry. This should be of format: <acct_id>.dkr.ecr.<region>.amazonaws.com
+.. In *Registry*, enter the URL for the registry. This should be of format: *<acct_id>.dkr.ecr.<region>.amazonaws.com*
 
 .. In *Repository*, enter the name of the repository to scan.
 

--- a/compute/admin_guide/vulnerability_management/registry_scanning/scan_ecr.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/scan_ecr.adoc
@@ -48,7 +48,7 @@ The *AmazonEC2ContainerRegistryReadOnly* permissions policy is currently defined
 
 .. In *Version*, select *Amazon EC2 Container Registry*.
 
-.. In *Registry*, enter the URL for the registry.
+.. In *Registry*, enter the URL for the registry. This should be of format: <acct_id>.dkr.ecr.<region>.amazonaws.com
 
 .. In *Repository*, enter the name of the repository to scan.
 


### PR DESCRIPTION
It's important to get this syntax correct, otherwise scans do not work and unfortunately Prisma Cloud does not tell you this is wrong.  This additional detail will help ensure users enter correct URL format for this field.