### PR TITLE
Explicitly state what is dropped

### DIFF
--- a/compute/admin_guide/compliance/custom_compliance_checks.adoc
+++ b/compute/admin_guide/compliance/custom_compliance_checks.adoc
@@ -30,7 +30,7 @@ Every compliance check in the system has a unique ID.
 Custom checks are automatically assigned an ID, starting with the number 9000.
 As new custom checks are added, they are automatically assigned the next available ID (9001, 9002, and so on).
 
-NOTE: If a new rule with custom compliance checks is added, or an existing rule is updated with a new custom compliance check, Prisma Cloud drops the cached scan results for registries, and rescans registry images.
+NOTE: If a new rule with custom compliance checks is added, or an existing rule is updated with a new custom compliance check, Prisma Cloud drops the cached compliance and vulnerability scan results for registries, and rescans registry images.
 In a scaled-out environment with large registries, repeated changes to custom compliance checks could have a negative impact on Prisma Cloud's performance.
 
 


### PR DESCRIPTION
Update to explicitly state compliance and vulnerability data is dropped when updating custom compliance rules.

