### PR TITLE
Update auto_defend_host.adoc

### DIFF
--- a/compute/admin_guide/install/install_defender/auto_defend_host.adoc
+++ b/compute/admin_guide/install/install_defender/auto_defend_host.adoc
@@ -92,17 +92,17 @@ Add the following policy to an IAM user or role:
 
 === Azure virtual machines
 
-Prisma Cloud uses Azure VM agent’s https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command)[Run Command] option to invoke the script to deploy Host defenders.
-Users are required to configure the permissions below in your subscription and create host deploy rules to begin installing the defenders.
+Prisma Cloud uses the Azure VM agent https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command)[Run Command] option to invoke the script to deploy Host defenders.
+You are required to configure the permissions below in your subscription and create host deploy rules to begin installing Defenders.
 
 
 ==== Minimum requirements
 
-The following sections describe the minimum requires to auto-defend to hosts in Azure.
+The following sections describe the minimum requires to auto-defend to hosts on Azure.
 
 ===== Azure Linux VM agent & Run command
 
-Prisma Cloud uses Azure Linux VM agent’s `run command` action to deploy Defenders to instances. 
+Prisma Cloud uses the `run command` action on the Azure Linux VM agent to deploy Defenders on instances. 
 
 The VM Agent must be on every instance. 
 By default, the VM agent is available on most Linux OS machines.
@@ -114,7 +114,7 @@ Also, run command is only supported on Linux VMs.
 
 ===== Required permissions
 
-In addition to the  https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)[Reader] role to get the list and details of the virtual machines, the Azure credential user needs permissions to invoke runcommand
+In addition to the  https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)[Reader] role to get the list and details of the virtual machines, the Azure credential user needs permissions to invoke the runcommand.
 
 ----
 Microsoft.Compute/virtualMachines/runCommand/action
@@ -125,15 +125,15 @@ Typically,  the Virtual Machine https://docs.microsoft.com/en-us/azure/role-base
 === GCP Compute Engine instances
 
 The installation uses  https://cloud.google.com/compute/docs/os-patch-management[OS Patch Management] service.
-Prisma creates an OS patch job with the information of the installation script stored in the temporarily created storage bucket and the list of instances to deploy the Host defender on the instances.
+Prisma Cloud creates an OS patch job with the information of the installation script stored in the temporarily created storage bucket and the list of instances to deploy the Host defender on the instances.
 
 ==== Minimum requirements
 
-The following sections describe the minimum requires to auto-defend to hosts in GCP.
+The following sections describe the minimum requires to auto-defend hosts on GCP.
 
 ===== Storage Buckets
 
-Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region selected during the auto defend rule.
+Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region you selected in the auto-protect rule.
 The Prisma defender installation script 'prisma-defender-script.sh' is stored in the bucket.
 
 The service account user needs permissions to be able to create and delete the bucket.

--- a/compute/admin_guide/install/install_defender/auto_defend_host.adoc
+++ b/compute/admin_guide/install/install_defender/auto_defend_host.adoc
@@ -133,7 +133,7 @@ The following sections describe the minimum requires to auto-defend hosts on GCP
 
 ===== Storage Buckets
 
-Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region you selected in the auto-protect rule.
+Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region you selected in the auto-defend rule.
 The Prisma defender installation script 'prisma-defender-script.sh' is stored in the bucket.
 
 The service account user needs permissions to be able to create and delete the bucket.
@@ -191,7 +191,7 @@ Auto-defend doesn't currently check if a host is part of cluster.
 If you  mistakenly include nodes that are part of a cluster in an auto-defend rule, and the cluster is not already protected, the auto-defend rule will deploy Host Defenders to the cluster nodes.
 
 [.task]
-=== Add a host auto-protect rule
+=== Add a host auto-defend rule
 
 Host auto-defend rules let you specify which hosts you want to protect.
 You can define a specific account by referencing the relevant credential or collection.
@@ -219,7 +219,10 @@ The following example shows a collection that is based on hosts labels, in this 
 +
 image::auto_defend_collection_example.png[width=600]
 
-.. Specify the scanning scope.
+.. Set up these options for specific Cloud Service Providers.
++
+ * (For AWS only) Specify the Scanning scope for the AWS region- Commercial or regular, Government, or China.
+ * (For GCP only) Specify the Bucket region. Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region and deletes it after the process of creating the rule is completed.
 
 .. Select or xref:../../authentication/credentials_store.adoc[create credentials] so Prisma Cloud can access your account.
 The service account must have the minimum permissions specified <<_perms,here>>.
@@ -228,11 +231,11 @@ The service account must have the minimum permissions specified <<_perms,here>>.
 +
 The new rule appears in the table of rules.
 
-. Click *Apply*. 
+. Click *Apply Defense*. 
 +
-A scan starts.
+Select the rule to start the scan.
 By default, host auto-protect rules are evaluated every 24 hours. 
-Click the *Apply* button to force a new scan.
+Click the *Apply Defense* button to force a new scan.
 +
 The following screenshot shows that the `auto-defend-testgroup` discovered two EC2 instances and deployed two Defenders (2/2).
 +

--- a/compute/admin_guide/install/install_defender/auto_defend_host.adoc
+++ b/compute/admin_guide/install/install_defender/auto_defend_host.adoc
@@ -206,7 +206,7 @@ Each auto-defend rule is evaluated separately.
 
 .. Enter a rule name.
 
-.. In *Provider* - only AWS is supported.
+.. In *Provider* - AWS, Azure and GCP are currently supported.
 
 .. In *Console*, specify a DNS name or IP address that the installed Defender can use to connect back to Console after it's installed.
 


### PR DESCRIPTION
Added Azure and GCP as supported providers, not only AWS.

