### PR TITLE
update defendertypes.adoc

### DIFF
--- a/compute/admin_guide/install/defender_types.adoc
+++ b/compute/admin_guide/install/defender_types.adoc
@@ -47,7 +47,7 @@ Stand-alone Container Defenders are installed on hosts that are not part of a cl
 Host Defender utilizes Prisma Cloud's model-based approach for protecting hosts that do not run containers.
 This Defender type lets you extend Prisma Cloud to protect all the hosts in your environment, regardless of their purpose.
 Defender runs as a systemd service on Linux and a Windows service on Windows.
-
+If Docker is deployed on your host, deploy a container Defender to protect the containers and the underlying host.
 
 Deploy one Host Defender per host.
 Do not deploy Host Defender if you've already deployed Container Defender to a host.

--- a/compute/admin_guide/install/defender_types.adoc
+++ b/compute/admin_guide/install/defender_types.adoc
@@ -47,7 +47,7 @@ Stand-alone Container Defenders are installed on hosts that are not part of a cl
 Host Defender utilizes Prisma Cloud's model-based approach for protecting hosts that do not run containers.
 This Defender type lets you extend Prisma Cloud to protect all the hosts in your environment, regardless of their purpose.
 Defender runs as a systemd service on Linux and a Windows service on Windows.
-If Docker Engine is detected on the host, installation of this Defender type is blocked; install Container Defender instead.
+
 
 Deploy one Host Defender per host.
 Do not deploy Host Defender if you've already deployed Container Defender to a host.


### PR DESCRIPTION
If Docker Engine is detected on the host, installation of this Defender type is blocked; install Container Defender instead. - this is not longer the functionality, you can install a host defender on a host with docker if you wish.

