### PR TITLE
Update supply-chain-security.adoc

### DIFF
--- a/code-security/admin_guide/scan-monitor/supply-chain-security.adoc
+++ b/code-security/admin_guide/scan-monitor/supply-chain-security.adoc
@@ -1,7 +1,7 @@
 
 == Supply Chain Security
 
-To successfully secure your software supply chain, you need to understand the connection between your current infrastructure and application security. The supply chain capability on Code Security is a code-centric view of your infrastructure and application security that visualizes a supply chain graph, starting with the IaC templates, through the services, through deployed cloud workload resources including associated permissions, and the runtime configuration on these resources.  For example, a compromise in your infrastructure may exist if you have an upstream vulnerability in one of the resources that can affect your application. Knowing about this is critical to patch your code and mitigate exposure.
+To successfully secure your software supply chain, you need to understand the connection between your current infrastructure and application security. The supply chain capability on Code Security is a code-centric view of your infrastructure and application security that visualizes a supply chain graph, starting with the IaC templates, through the services.  For example, a compromise in your infrastructure may exist if you have an upstream vulnerability in one of the resources that can affect your application, and knowing about this is critical to patch your code and mitigate exposure.
 
 The supply chain graph is a real-time auto-discovery of potentially misconfigured infrastructure and application files, sorted into a neat data model that you can use to prioritize and search. The supply chain graph applies a new data model to the existing scanner findings. The scanners show data points as passed or failed policies and include a known vulnerability. The graph connects these data points of actual utilization of the resources in a running application and shows how different attributes and infrastructure are connected and interdependent.
 
@@ -35,9 +35,6 @@ image::supply-chain-repo-resource.png[width=600]
 The metadata on how the resource is configured and history of previous misconfigurations.
 +
 image::supply-chain-res-exp.png[width=600]
-
-* *Runtime Resource.*
-View the runtime resource that is triggered and the runtime configuration along with Resource history and audit trail.
 
 
 [.task]


### PR DESCRIPTION
Deleted: Runtime Resource. View the runtime resource that is triggered and the runtime configuration along with Resource history and audit trail.  
Removed:  through the services, <<through deployed cloud workload resources including associated permissions, and the runtime configuration on these resources>>.

