### PR TITLE
Update install_host_defender.adoc

### DIFF
--- a/compute/admin_guide/install/install_defender/install_host_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_host_defender.adoc
@@ -91,11 +91,14 @@ Console and Defender communicate with each other over a web socket on port 8084.
 Defender initiates the connection.
 Port 8084 is the default setting, but it is customizable when first installing Console.
 When deploying Defender, you can configure it to communicate to Console via a proxy.
+* You've created a service account with the Defender Manager role.
+twistcli uses the service account to access Console.
 endif::compute_edition[]
 * Console can be accessed over the network from the host where you want to install Defender.
 * You have sudo access to the host where Defender will be installed.
-* You've created a service account with the Defender Manager role. For the SaaS console you need to create a Role with Cloud Provisioning Admin permissions and **NO** account groups attached. 
-twistcl uses the service account to access Console.
+ifdef::prisma_cloud[]
+* Create a Role with Cloud Provisioning Admin permissions and without *any* account groups attached. 
+endif::prisma_cloud[]
 
 [.procedure]
 . Verify that the host machine where you install Defender can connect to Console.

--- a/compute/admin_guide/install/install_defender/install_host_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_host_defender.adoc
@@ -94,7 +94,7 @@ When deploying Defender, you can configure it to communicate to Console via a pr
 endif::compute_edition[]
 * Console can be accessed over the network from the host where you want to install Defender.
 * You have sudo access to the host where Defender will be installed.
-* You've created a service account with the Defender Manager role.
+* You've created a service account with the Defender Manager role. For the SaaS console you need to create a Role with Cloud Provisioning Admin permissions and **NO** account groups attached. 
 twistcl uses the service account to access Console.
 
 [.procedure]


### PR DESCRIPTION
The  requirements for installing a defender on a standalone hosts are inadequate when dealing with a SaaS console. The Permission Group for the Role necessary is Cloud Provisioning Admin not Defender Manager. Also there cannot be any Accounts Groups associated with the Role used to create the Service Account, otherwise the curl command appears to work but really only download an http error page which is not apparent because its saved as twistcli per the curl command.

