### PR TITLE
update-serverless.adoc

### DIFF
--- a/compute/admin_guide/compliance/serverless.adoc
+++ b/compute/admin_guide/compliance/serverless.adoc
@@ -158,38 +158,7 @@ If you wish to add an account, click on *Add credential*.
  
 .. Click *Add*.
 
-=== Authenticating with AWS
-
-The serverless scanner is implemented as part of Console.
-The scanner requires the following permissions policy:
-+
-[source,json]
-----
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "PrismaCloudComputeServerlessScan",
-            "Effect": "Allow",
-            "Action": [
-                "lambda:ListFunctions",
-                "lambda:GetFunction",
-                "iam:GetPolicy",
-                "iam:GetPolicyVersion",
-                "iam:GetRole",
-                "iam:GetRolePolicy",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListRolePolicies",
-                "lambda:GetLayerVersion",
-                "kms:Decrypt"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-----
-
-
+. Verify that you have assigned the xref:../vulnerability_management/serverless_functions.adoc#_authenticating_with_aws[correct permissions] required to scan.
 
 . To view the scan report, go to *Monitor > Compliance > Functions*.
 

--- a/compute/admin_guide/compliance/serverless.adoc
+++ b/compute/admin_guide/compliance/serverless.adoc
@@ -158,6 +158,39 @@ If you wish to add an account, click on *Add credential*.
  
 .. Click *Add*.
 
+=== Authenticating with AWS
+
+The serverless scanner is implemented as part of Console.
+The scanner requires the following permissions policy:
++
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PrismaCloudComputeServerlessScan",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:ListFunctions",
+                "lambda:GetFunction",
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:GetRole",
+                "iam:GetRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "lambda:GetLayerVersion",
+                "kms:Decrypt"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+----
+
+
+
 . To view the scan report, go to *Monitor > Compliance > Functions*.
 
 + 


### PR DESCRIPTION
AWS account permissions are not listed in compliance for function scanning . This can be confusing if for some reason a customer is setting up compliance checks but not vulnerability scanning.

