### PR TITLE
Update logging.adoc

### DIFF
--- a/compute/admin_guide/audit/logging.adoc
+++ b/compute/admin_guide/audit/logging.adoc
@@ -377,7 +377,7 @@ Example host compliance issue:
  Jul 30 22:09:53 aqsa-root Twistlock-Console[1]: 
   time="2019-07-30T22:09:53.390585517Z" 
   type="host_scan" 
-  log_type="containerCompliance" 
+  log_type="compliance" 
   compliance_id="6518" 
   severity="high" 
   description="(CIS_Linux_1.1.0 - 5.1.8) Ensure at/cron is restricted to authorized users" 


### PR DESCRIPTION
log_type for "Example host compliance issue" section should be "compliance"

Sample event:
<142>May 25 20:55:01 master-anitguru-svanallen-demo-twistlock-com Twistlock-Console[1]: time="2022-05-25T20:55:01.836284472Z" type="host_scan" log_type="compliance" compliance_id="449" severity="high" description="Ensure no pending OS security updates" rule="Default - alert on critical and high" host="master-anitguru-svanallen-demo-twistlock-com" labels="osDistro:ubuntu,osVersion:16.04" collections="All"

