### PR TITLE
Added setup of external route for Defenders comms

### DIFF
--- a/compute/admin_guide/install/install_openshift_4.adoc
+++ b/compute/admin_guide/install/install_openshift_4.adoc
@@ -389,7 +389,7 @@ If you plan to issue a xref:../configure/certificates.adoc[custom certificate fo
 [.task]
 ==== Create an external route to Console for external Defenders
 
-If you are planning to deploy Defenders to another cluster and report to this Console, you will need to create an additional external route to Console so that the Defenders can access the Console over port 8084.
+If you are planning to deploy Defenders to another cluster and report to this Console, you will need to create an additional external route to Console so that the Defenders can access the Console. You need to expose the Prisma Cloud-Console service’s TCP port 8084 as external OpenShift routes. Each route will be an unique, fully qualified domain name.
 
 [.procedure]
 . From the OpenShift web interface, go to the _twistlock_ project.
@@ -412,7 +412,7 @@ If you are planning to deploy Defenders to another cluster and report to this Co
 
 . TLS Termination = Passthrough (if using 8084)
 +
-If you plan to issue a xref:../configure/certificates.adoc[custom certificate for Console TLS communication] that is trusted and will allow the TLS establishment with the Prisma Cloud Console, then Select Passthrough TLS for TCP port 8084.
+NOTE: The Defender to Console communication is a mutual TLS secure websocket session. This communication cannot be intercepted.
 
 . Insecure Traffic = *Redirect*
 
@@ -486,7 +486,14 @@ The location where you run twistcli (inside or outside the cluster) dictates whi
 
 The _--cluster-address_ flag specifies the address Defender uses to connect to Console.
 For Defenders deployed inside the cluster, specify Prisma Cloud Console’s service name, twistlock-console or twistlock-console.twistlock.svc, or cluster IP address.
-For Defenders deployed outside the cluster, specify the external route for the Console over port 8084 created before, _twistlock-console-8084.apps.ose.example.com_, if the external route is not exposing port 8084, specify the port in the address, e.g. _twistlock-console-8084.apps.ose.example.com:443_.
+For Defenders deployed outside the cluster, specify the external route for the Console over port 8084 created before, _twistlock-console-8084.apps.ose.example.com_, if the external route is not exposing port 8084, specify the port in the address, e.g. _twistlock-console-8084.apps.ose.example.com:443_ within the defender daemonSet yaml.
+
+Example: Edit the resulting defender.yaml and change:
+   - name: WS_ADDRESS
+            value: wss://twistlock-console-8084.apps.ose.example.com:8084
+to
+  - name: WS_ADDRESS
+            value: wss://twistlock-console-8084.apps.ose.example.com:443
 
 If SELinux is enabled on the OpenShift nodes, pass the _--selinux-enabled_ argument to twistcli.
 

--- a/compute/admin_guide/install/install_openshift_4.adoc
+++ b/compute/admin_guide/install/install_openshift_4.adoc
@@ -386,6 +386,38 @@ If you plan to issue a xref:../configure/certificates.adoc[custom certificate fo
 
 . Click *Create*.
 
+[.task]
+==== Create an external route to Console for external Defenders
+
+If you are planning to deploy Defenders to another cluster and report to this Console, you will need to create an additional external route to Console so that the Defenders can access the Console over port 8084.
+
+[.procedure]
+. From the OpenShift web interface, go to the _twistlock_ project.
+
+. Go to *Application > Routes*.
+
+. Select *Create Route*.
+
+. Enter a name for the route, such as *twistlock-console-8084*.
+
+. Hostname = URL used to access the Console, using a different hostname, e.g. _twistlock-console-8084.apps.ose.example.com_
+
+. Path = */*
+
+. Service = *twistlock-console*
+
+. Target Port = 8084 → 8084
+
+. Select the *Security > Secure Route* radio button.
+
+. TLS Termination = Passthrough (if using 8084)
++
+If you plan to issue a xref:../configure/certificates.adoc[custom certificate for Console TLS communication] that is trusted and will allow the TLS establishment with the Prisma Cloud Console, then Select Passthrough TLS for TCP port 8084.
+
+. Insecure Traffic = *Redirect*
+
+. Click *Create*.
+
 endif::compute_edition[]
 
 
@@ -405,6 +437,8 @@ Create your first admin user, enter your license key, and configure Console's ce
 . Add a SubjectAlternativeName to Console's certificate to allow Defenders to establish a secure connection with Console.
 +
 Use either Console's service name, _twistlock-console_ or _twistlock-console.twistlock.svc_, or Console's cluster IP.
++
+Additionally, if a route for external Defenders was created, add that one to the SAN list too: __twistlock-console-8084.apps.ose.example.com_
 +
   $ oc get svc -n twistlock
   NAME                TYPE           CLUSTER-IP     EXTERNAL-IP                 PORT(S)
@@ -452,7 +486,7 @@ The location where you run twistcli (inside or outside the cluster) dictates whi
 
 The _--cluster-address_ flag specifies the address Defender uses to connect to Console.
 For Defenders deployed inside the cluster, specify Prisma Cloud Console’s service name, twistlock-console or twistlock-console.twistlock.svc, or cluster IP address.
-For Defenders deployed outside the cluster, specify either Console’s external address, which is exposed by your external route.
+For Defenders deployed outside the cluster, specify the external route for the console over port 8084 created before, __twistlock-console-8084.apps.ose.example.com_, if the external route is not exposing port 8084, specify the port in the address, e.g. __twistlock-console-8084.apps.ose.example.com:443_.
 
 If SELinux is enabled on the OpenShift nodes, pass the _--selinux-enabled_ argument to twistcli.
 

--- a/compute/admin_guide/install/install_openshift_4.adoc
+++ b/compute/admin_guide/install/install_openshift_4.adoc
@@ -438,7 +438,7 @@ Create your first admin user, enter your license key, and configure Console's ce
 +
 Use either Console's service name, _twistlock-console_ or _twistlock-console.twistlock.svc_, or Console's cluster IP.
 +
-Additionally, if a route for external Defenders was created, add that one to the SAN list too: __twistlock-console-8084.apps.ose.example.com_
+Additionally, if a route for external Defenders was created, add that one to the SAN list too: _twistlock-console-8084.apps.ose.example.com_
 +
   $ oc get svc -n twistlock
   NAME                TYPE           CLUSTER-IP     EXTERNAL-IP                 PORT(S)
@@ -486,7 +486,7 @@ The location where you run twistcli (inside or outside the cluster) dictates whi
 
 The _--cluster-address_ flag specifies the address Defender uses to connect to Console.
 For Defenders deployed inside the cluster, specify Prisma Cloud Console’s service name, twistlock-console or twistlock-console.twistlock.svc, or cluster IP address.
-For Defenders deployed outside the cluster, specify the external route for the console over port 8084 created before, __twistlock-console-8084.apps.ose.example.com_, if the external route is not exposing port 8084, specify the port in the address, e.g. __twistlock-console-8084.apps.ose.example.com:443_.
+For Defenders deployed outside the cluster, specify the external route for the Console over port 8084 created before, _twistlock-console-8084.apps.ose.example.com_, if the external route is not exposing port 8084, specify the port in the address, e.g. _twistlock-console-8084.apps.ose.example.com:443_.
 
 If SELinux is enabled on the OpenShift nodes, pass the _--selinux-enabled_ argument to twistcli.
 


### PR DESCRIPTION
I found the current instructions for OpenShift 4 didn't allow the communication of external Defenders back to the Console, so I:
Added the definition of an external route to expose port 8084 to enable communication of Defenders to the Console.
Added setup of the route's URL in the SAN of the console, and in the Defender installation instructions, also adding the option to specify the target port from the external Defender point of view.

