### PR TITLE
update-configure-scan-intervals.adoc

### DIFF
--- a/compute/admin_guide/configure/configure_scan_intervals.adoc
+++ b/compute/admin_guide/configure/configure_scan_intervals.adoc
@@ -48,11 +48,6 @@ When Defender is delegated the registry scanner role, you can also see the last 
 
 image::configure_scan_intervals_defender_details.png[width=500]
 
-Defender roles are displayed in the *Manage > Defenders > Manage* table.
-The following screenshot shows that Defender on host ian-23 is a registry scanner.
-
-image::configure_scan_intervals_defender_list.png[width=800]
-
 
 === Scan performance
 


### PR DESCRIPTION
Defender roles is no longer a feature shown in this UI element 
Internal TAC PR from SI - no PCSUP

This page needs image update and a revamp- will revisit more later.