### PR TITLE
docs: Linking the log files to the correct logging page(#267)

### DIFF
--- a/compute/ref_arch/security_data/log_files.adoc
+++ b/compute/ref_arch/security_data/log_files.adoc
@@ -2,9 +2,7 @@
 
 Prisma Cloud writes to RFC compliant syslog, this syslog data can be
 injected by any number of time series data solutions as well as common
-SIEM solutions. Twitlock offers a few layers of detail in our syslog
+SIEM solutions. Prisma cloud offers a few layers of detail in our syslog
 messages which you can select to increase the verbosity of the messages.
-Prisma Cloud recommends leaving the messages at their defaults Prisma Cloud
-can also write to STDOUT as well as feed in to Prometheus. For more
-information see our 
-https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-guide-compute/audit/logging.html[logging documentation].
+Prisma Cloud recommends leaving the messages at their defaults and it can also write to STDOUT as well as feed into Prometheus. For more
+information see our https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-01/prisma-cloud-compute-edition-admin/audit/logging[logging documentation].

--- a/compute/ref_arch/security_data/log_files.adoc
+++ b/compute/ref_arch/security_data/log_files.adoc
@@ -2,7 +2,7 @@
 
 Prisma Cloud writes to RFC compliant syslog, this syslog data can be
 injected by any number of time series data solutions as well as common
-SIEM solutions. Prisma cloud offers a few layers of detail in our syslog
+SIEM solutions. Prisma Cloud offers a few layers of detail in our syslog
 messages which you can select to increase the verbosity of the messages.
 Prisma Cloud recommends leaving the messages at their defaults and it can also write to STDOUT as well as feed into Prometheus. For more
 information see our logging documentation for https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute/audit/logging[Enterprise Edition] or https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-06/prisma-cloud-compute-edition-admin/audit/logging[Compute edition].

--- a/compute/ref_arch/security_data/log_files.adoc
+++ b/compute/ref_arch/security_data/log_files.adoc
@@ -5,4 +5,4 @@ injected by any number of time series data solutions as well as common
 SIEM solutions. Prisma cloud offers a few layers of detail in our syslog
 messages which you can select to increase the verbosity of the messages.
 Prisma Cloud recommends leaving the messages at their defaults and it can also write to STDOUT as well as feed into Prometheus. For more
-information see our https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-01/prisma-cloud-compute-edition-admin/audit/logging[logging documentation].
+information see our logging documentation for https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute/audit/logging[Enterprise Edition] or https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-06/prisma-cloud-compute-edition-admin/audit/logging[Compute edition].


### PR DESCRIPTION
## Description

Edited the logging documentation link as: `https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-01/prisma-cloud-compute-edition-admin/audit/logging` in the [Log files]() page.

## Referencing Issue

This PR refers to the [issue](#267).

* [x] This PR includes documentation change.