### PR TITLE
Update documentation to include .Net Core

### DIFF
--- a/compute/admin_guide/continuous_integration/code_repo_scanning.adoc
+++ b/compute/admin_guide/continuous_integration/code_repo_scanning.adoc
@@ -9,6 +9,7 @@ The runtimes supported are:
 * Node.js
 * Python
 * Ruby
+* C# (.NET Core 2.1, .NET Core 3.1) 
 
 [.task]
 === Integrate code scanning into CI builds


### PR DESCRIPTION
Customer asked if we support .Net Core and sent me a link to this doc.  They sent screen shots of .Net Core being scanned in their repo.  I also looked in Slack and saw others asking if this was supported, therefore, submitting this request to have the documentation updated.

