### PR TITLE
[PCSUP-9395] Malware scanning and Wildfire (#39520)

### DIFF
--- a/compute/admin_guide/configure/wildfire.adoc
+++ b/compute/admin_guide/configure/wildfire.adoc
@@ -60,12 +60,14 @@ Currently Prisma Cloud Compute uses WildFire for file verdicts only in the follo
 
 * Hosts runtime: 
 
-**  ELF files written to a linux host file system in runtime, which are not deployed via a package manager.
+** ELF files written to a Linux host file system in runtime, which are not deployed via a package manager.
 ** Files must be smaller than 100MB (WildFire limit)
 
 * Container runtime / CI:
-** ELF files written to a linux container file system in runtime, which are not deployed via a package manager. Malware analysis not supported for other file types.
-** Objects that are not shared. Shared objects are not scanned by WildFire.
+** ELF files written to a Linux container file system in runtime. Malware analysis not supported for other file types.
++
+During CI scanning, only executable files that were not written as part of a package installation will be analyzed by WildFire.
+** Shared objects are not scanned by WildFire.
 ** File must be smaller than 100MB (WildFire limit).
 
 NOTE:

--- a/compute/admin_guide/configure/wildfire.adoc
+++ b/compute/admin_guide/configure/wildfire.adoc
@@ -64,12 +64,14 @@ Currently Prisma Cloud Compute uses WildFire for file verdicts only in the follo
 ** Files must be smaller than 100MB (WildFire limit)
 
 * Container runtime / CI:
-** ELF files written to a linux container file system in runtime.
-** Shared objects are not examined via WildFire.
+** ELF files written to a linux container file system in runtime, which are not deployed via a package manager.
+** Objects that are not shared. Shared objects are not scanned by WildFire.
 ** File must be smaller than 100MB (WildFire limit).
 
-NOTE: You can submit up to 5000 files per day, and get up to 50,000 verdicts on your submissions to the WildFire service.
+NOTE:
 
-NOTE: Wildfire is supported on Linux only.
+* You can submit up to 5000 files per day, and get up to 50,000 verdicts on your submissions to the WildFire service.
+* Wildfire is supported on Linux only.
++
 Windows containers and hosts aren't currently supported.
 

--- a/compute/admin_guide/configure/wildfire.adoc
+++ b/compute/admin_guide/configure/wildfire.adoc
@@ -64,7 +64,7 @@ Currently Prisma Cloud Compute uses WildFire for file verdicts only in the follo
 ** Files must be smaller than 100MB (WildFire limit)
 
 * Container runtime / CI:
-** ELF files written to a linux container file system in runtime, which are not deployed via a package manager.
+** ELF files written to a linux container file system in runtime, which are not deployed via a package manager. Malware analysis not supported for other file types.
 ** Objects that are not shared. Shared objects are not scanned by WildFire.
 ** File must be smaller than 100MB (WildFire limit).
 

--- a/compute/admin_guide/vulnerability_management/malware_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/malware_scanning.adoc
@@ -3,8 +3,9 @@
 Besides detecting software vulnerabilities (CVEs) and compliance issues (such as images configured to run as root), Prisma Cloud also detects malware in your container images.
 No special configuration is required to enable this feature.
 
-Malware data is sourced from commercial providers, Prisma Cloud Labs, and open source lists.
-The image scanner looks for malware in binaries in the image layers, including the base layer.
+Malware analysis uses the data from Intelligence Stream, the xref:../configure/wildfire.adoc [Wildfire service], and custom feeds. Uploads to WildFire for malware analysis does not apply to Defenders, it is only for container CI and runtime protection for containers and hosts.  When using Defenders to scan images in a registry or images that are deployed, the MD5 checksum is used.
+
+See xref:../configure/custom_feeds.adoc#malware-signatures[Import custom malware data], for information on how to upload custom malware data to Console and use it for image scanning.
 
 NOTE: Malware scanning and detection is supported for Linux container images only.
 Windows containers are not supported.
@@ -13,7 +14,7 @@ Windows containers are not supported.
 [.task]
 === Detecting malware
 
-When Prisma Cloud detects malware in an image, it logs the vulnerability in the image scan report.
+The image scanner looks for malware in binaries in the image layers, including the base layer. When Prisma Cloud detects malware in an image, it logs the vulnerability in the image scan report.
 
 To review the results of an image scan:
 
@@ -27,10 +28,4 @@ To review the results of an image scan:
 Issues with vulnerability ID 422 means that your image contains a file with an md5 signature of known malware.
 
 
-=== What's next?
 
-Custom malware data can be uploaded to Prisma Cloud.
-After uploading your data, it is used in all subsequent images scans.
-
-For more information about uploading custom malware data to Console, see
-xref:../configure/custom_feeds.adoc#malware-signatures[Import custom malware data].

--- a/compute/admin_guide/vulnerability_management/malware_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/malware_scanning.adoc
@@ -3,9 +3,13 @@
 Besides detecting software vulnerabilities (CVEs) and compliance issues (such as images configured to run as root), Prisma Cloud also detects malware in your container images.
 No special configuration is required to enable this feature.
 
-Malware analysis uses the data from Intelligence Stream, the xref:../configure/wildfire.adoc [Wildfire service], and custom feeds. Uploads to WildFire for malware analysis does not apply to Defenders, it is only for container CI and runtime protection for containers and hosts.  When using Defenders to scan images in a registry or images that are deployed, the MD5 signature is used.
+To perform malware analysis, Prisma Cloud uses the inputs from:
 
-See xref:../configure/custom_feeds.adoc#malware-signatures[Import custom malware data], for information on how to upload custom malware data to Console and use it for image scanning.
+* xref:../vulnerability_management/prisma_cloud_vulnerability_feed.adoc [Intelligence Stream]—Searches the feed for a match against the hash for the executable.
+* xref:../configure/wildfire.adoc [Wildfire service]—Queries the WildFire service for a match against the hash for the executable. If there is no match and upload is enabled, the file is uploaded for analysis. 
++
+NOTE: WildFire is only supported for image scanning when used in CI.
+* Custom feeds—Searches for a match for the executable hash against any xref:../configure/custom_feeds.adoc#malware-signatures[custom malware data you import] for image scanning.
 
 NOTE: Malware scanning and detection is supported for Linux container images only.
 Windows containers are not supported.
@@ -14,7 +18,7 @@ Windows containers are not supported.
 [.task]
 === Detecting malware
 
-The image scanner looks for malware in binaries in the image layers, including the base layer. When Prisma Cloud detects malware in an image, it logs the vulnerability in the image scan report.
+The image scanner looks for malware in binaries in the image layers, including the base layer. When Prisma Cloud detects malware in an image, it includes the malware information as a compliance violation in the image scan report.
 
 To review the results of an image scan:
 

--- a/compute/admin_guide/vulnerability_management/malware_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/malware_scanning.adoc
@@ -3,7 +3,7 @@
 Besides detecting software vulnerabilities (CVEs) and compliance issues (such as images configured to run as root), Prisma Cloud also detects malware in your container images.
 No special configuration is required to enable this feature.
 
-Malware analysis uses the data from Intelligence Stream, the xref:../configure/wildfire.adoc [Wildfire service], and custom feeds. Uploads to WildFire for malware analysis does not apply to Defenders, it is only for container CI and runtime protection for containers and hosts.  When using Defenders to scan images in a registry or images that are deployed, the MD5 checksum is used.
+Malware analysis uses the data from Intelligence Stream, the xref:../configure/wildfire.adoc [Wildfire service], and custom feeds. Uploads to WildFire for malware analysis does not apply to Defenders, it is only for container CI and runtime protection for containers and hosts.  When using Defenders to scan images in a registry or images that are deployed, the MD5 signature is used.
 
 See xref:../configure/custom_feeds.adoc#malware-signatures[Import custom malware data], for information on how to upload custom malware data to Console and use it for image scanning.
 


### PR DESCRIPTION
Changes to clarify that for container/CI scanning, only executable files that were not installed with a package manager are checked with wildfire.

