### PR TITLE
Removing openShift3.11 reference from how-to sections

### DIFF
--- a/compute/admin_guide/howto/openshift_build_twistcli_scanning.adoc
+++ b/compute/admin_guide/howto/openshift_build_twistcli_scanning.adoc
@@ -56,7 +56,7 @@ See <<OpenShift secret for the Prisma Cloud credentials>>.
 
 *Prerequisites:*
 Prisma Cloud Console is fully operational.
-See the Prisma Cloud xref:../install/install_openshift_3_11.adoc[OpenShift 3.11] and xref:../install/install_openshift_4.adoc[OpenShift 4] deployment guides.
+See the Prisma Cloud xref:../install/install_openshift_4.adoc[OpenShift 4] deployment guide.
 
 Create a least privileged xref:../authentication/user_roles.adoc[CI User] account.
 

--- a/compute/admin_guide/howto/openshift_provision_tenant_projects.adoc
+++ b/compute/admin_guide/howto/openshift_provision_tenant_projects.adoc
@@ -17,7 +17,7 @@ In this example provisioning flow, the DNS names for Central Console and Supervi
 *Prerequisites:*
 
 * Two fully operational Prisma Cloud Consoles are already deployed.
-For more information, see the Prisma Cloud xref:../install/install_openshift_4.adoc[OpenShift 4] deployment guide.
+For more information, see the xref:../install/install_openshift_4.adoc[OpenShift 4] deployment.
 * OpenShift external routes to both Consoles' TCP port 8083 (Prisma Cloud UI and API), with the TLS termination type set to passthrough, already exist.
 * The to-be Central and Supervisor Consoles are already licensed and you've created initial admin users.
 

--- a/compute/admin_guide/howto/openshift_provision_tenant_projects.adoc
+++ b/compute/admin_guide/howto/openshift_provision_tenant_projects.adoc
@@ -17,7 +17,7 @@ In this example provisioning flow, the DNS names for Central Console and Supervi
 *Prerequisites:*
 
 * Two fully operational Prisma Cloud Consoles are already deployed.
-For more information, see the Prisma Cloud xref:../install/install_openshift_3_11.adoc[OpenShift 3.11] and xref:../install/install_openshift_4.adoc[OpenShift 4] deployment guides.
+For more information, see the Prisma Cloud xref:../install/install_openshift_4.adoc[OpenShift 4] deployment guide.
 * OpenShift external routes to both Consoles' TCP port 8083 (Prisma Cloud UI and API), with the TLS termination type set to passthrough, already exist.
 * The to-be Central and Supervisor Consoles are already licensed and you've created initial admin users.
 


### PR DESCRIPTION
Description: Two of the files in the how-to section still references openShift3.11

Referenced PR: [removing OpenShift 3.11 #399](https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/399)