### PR TITLE
[API Doc] GH # 37708 - `api/v22.01/audits/incidents` retrieves archive incidents

### DIFF
--- a/api/descriptions/audits/incidents_get.md
+++ b/api/descriptions/audits/incidents_get.md
@@ -6,12 +6,14 @@ This endpoint maps to the table in **Monitor > Runtime > Incident explorer** in 
 
 ### cURL Request
 
-Refer to the following example cURL command:
+Refer to the following example cURL command that retrieves a list of unacknowledged incidents (not in the archived state):
 
 ```bash
 $ curl -k \
   -u <USER> \
-  https://<CONSOLE>/api/v<VERSION>/audits/incidents
+  -H 'Content-Type: application/json' \
+  -X GET \
+  "https://<CONSOLE>/api/v<VERSION>/audits/incidents?acknowledged=false"
 ```
 
 A successful response returns the incidents.


### PR DESCRIPTION
Updated the cURL example to fetch the list of incidents that are not archived as discussed in GH #37708.