### PR TITLE
[RN22.06] Update to clarify deprecation notice

### DIFF
--- a/compute/rn/release-information/release-notes-22-06.adoc
+++ b/compute/rn/release-information/release-notes-22-06.adoc
@@ -665,10 +665,11 @@ Microsoft has announced the https://docs.microsoft.com/en-us/lifecycle/products/
 Support will be removed in the Newton release.
 
 // #36042
-* Support for scanning your code repositories and CI pipelines from the Prisma Cloud Compute console (*Monitor > Vulnerabilities > Code repositories*) and twistcli is being deprecated. 
+* Support for scanning your code repositories from the Prisma Cloud Compute console (*Monitor > Vulnerabilities > Code repositories*) is being deprecated. 
+Twistcli for code repository scanning is also being deprecated.
 You can use the Code Security module on Prisma Cloud to scan code repositories amd CI pipelines for misconfigurations and vulnerabilities.
 +
-Support for code repo scanning and CI pipelines using Prisma Cloud Compute will be removed in the Newton release.
+Support for code repo scanning using Prisma Cloud Compute will be removed in the Newton release.
 
 
 [#backward_compatibility]


### PR DESCRIPTION
#36042; CWP will not deprecating CI pipeline vulnerability scanning with twistcli only repo-scanning.

