### PR TITLE
[#39757+#39658]:Improve Vulnerability doc

### DIFF
--- a/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
+++ b/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
@@ -17,7 +17,7 @@ This analysis augments existing vulnerability detection and blocking mechanisms,
 [.section]
 === Supported apps
 
-The following list shows examples of the apps currently supported.
+The following list shows examples of the apps currently supported. xref:../tools/update_intel_stream_offline.adoc#[Download IS data] and read the `cve.json` file to get the most recent list of packages.
 
 * .NET Core
 * ASP.NET Core

--- a/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
+++ b/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
@@ -1,14 +1,17 @@
 == Detect vulnerabilities in unpackaged software
 
-Typically, software is added to container images and hosts with a package manager, such as apt, yum, npm.
-Prisma Cloud has a diverse set of upstream vulnerability data sources covering many different package managers across operating systems, including coverage for Go, Java, Node.js, Python, and Ruby components.
-Prisma Cloud typically uses the package manager’s metadata to discover installed components and versions, comparing this data to the data in the Intelligence Stream's realtime CVE feed.
+Typically, the software is added to container images and hosts with a package manager, such as `apt`, `yum`, and `npm`.
+Prisma Cloud has a diverse set of upstream vulnerability data sources covering many different package managers across operating systems, including coverage for `Go`, `Java`, `Node.js`, `Python`, and `Ruby` components.
+Prisma Cloud typically uses the package manager's metadata to discover installed components and versions, comparing this data to the data in the Intelligence Stream's real-time CVE feed.
+The host defender only scans the applications that are installed with a package manager on the host.
 
 Sometimes, you might install software without a package manager.
-For example, software might be built from source and then added to an image with the Dockerfile `ADD` instruction or your developers might unzip software from a tar ball to a location on a host, and utilize the application.
+For example, the software might be built from source and then added to an image with the Dockerfile `ADD` instruction, or your developers might unzip software from a tarball to a location on a host, and utilize the application.
 In these cases, there is no package manager data associated with the application.
 
-Prisma Cloud uses a variety of analysis techniques to detect metadata about software not installed by package managers. These are purpose built differently for images and hosts. 
+Prisma Cloud uses a variety of analysis techniques to detect metadata about software not installed by package managers. These are purpose-built differently for images and hosts.
+We scan the entire root volume In Agentless, and can detect third-party packages in addition to OS packages.
+
 This analysis augments existing vulnerability detection and blocking mechanisms, giving you a single view of all vulnerabilities, regardless of how the software is installed (distro's package manager, language runtime package manager, or without a package manager).
 
 [.section]
@@ -16,11 +19,22 @@ This analysis augments existing vulnerability detection and blocking mechanisms,
 
 The following list shows examples of the apps currently supported.
 
+* .NET Core
+* ASP.NET Core
+* BusyBox
+* Consul
+* CRI-O
+* Docker
+* GO
+* Istio
+* OMI
+* Vault
+* Websphere Application Server
+* Webshpere Open Liberty
 * Kubernetes
 * OpenShift
 * Jenkins
 * Envoy
-* CRIO
 * Hashicorp Vault
 * Hashicorp Consul
 * WordPress
@@ -39,7 +53,7 @@ The following list shows examples of the apps currently supported.
 
 Nothing is required to enable the functionality described in this article.
 It is enabled by default.
-For some apps such as for Python packages, the path is not included in the package info details for scan results on Monitor > Vulnerabilities.
+For some apps, such as Python packages, the path is not included in the package info details for scan results on *Monitor > Vulnerabilities*.
 
 When vulnerabilities are detected in an unpackaged app, scan reports list the *Type* as *Application*.
 

--- a/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
+++ b/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
@@ -10,7 +10,6 @@ For example, the software might be built from source and then added to an image 
 In these cases, there is no package manager data associated with the application.
 
 Prisma Cloud uses a variety of analysis techniques to detect metadata about software not installed by package managers. These are purpose-built differently for images and hosts.
-We scan the entire root volume In Agentless, and can detect third-party packages in addition to OS packages.
 
 This analysis augments existing vulnerability detection and blocking mechanisms, giving you a single view of all vulnerabilities, regardless of how the software is installed (distro's package manager, language runtime package manager, or without a package manager).
 

--- a/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
+++ b/compute/admin_guide/vulnerability_management/detect_vulns_unpackaged_software.adoc
@@ -3,7 +3,7 @@
 Typically, the software is added to container images and hosts with a package manager, such as `apt`, `yum`, and `npm`.
 Prisma Cloud has a diverse set of upstream vulnerability data sources covering many different package managers across operating systems, including coverage for `Go`, `Java`, `Node.js`, `Python`, and `Ruby` components.
 Prisma Cloud typically uses the package manager's metadata to discover installed components and versions, comparing this data to the data in the Intelligence Stream's real-time CVE feed.
-The host defender only scans the applications that are installed with a package manager on the host.
+The host defender only scans the running applications that are installed with a package manager on the host.
 
 Sometimes, you might install software without a package manager.
 For example, the software might be built from source and then added to an image with the Dockerfile `ADD` instruction, or your developers might unzip software from a tarball to a location on a host, and utilize the application.


### PR DESCRIPTION
## Issue
Downloaded files not scanned by the Host Defender

## Description

* Updated the supported package types (languages) and package managers list with new additions.
* Added info on host defender scans only running applications installed with a package manager.
* Agentless scans the entire root volume (FS) and can detect the third-party packages in addition to OS packages.

## References
[#39757](https://spring.paloaltonetworks.com/twistlock/twistlock/issues/39757)
[ #39658](https://spring.paloaltonetworks.com/twistlock/twistlock/issues/39658)
https://redlock.atlassian.net/browse/PCSUP-9970
https://redlock.atlassian.net/browse/PCC-1785
https://redlock.atlassian.net/browse/PCSUP-10071#icft=PCSUP-10071
https://redlock.atlassian.net/browse/PCC-1887
https://redlock.atlassian.net/browse/PCC-1881
https://redlock.atlassian.net/browse/PCC-1880
https://redlock.atlassian.net/browse/PCC-1864
https://redlock.atlassian.net/browse/PCC-1860
https://redlock.atlassian.net/browse/PCC-1856
https://redlock.atlassian.net/browse/PCC-1854
https://redlock.atlassian.net/browse/PCC-1836
https://redlock.atlassian.net/browse/PCC-1834
https://redlock.atlassian.net/browse/PCC-1832


