### PR TITLE
Remove suggestions to remove taints on nodes

### DIFF
--- a/compute/admin_guide/install/install_openshift_4.adoc
+++ b/compute/admin_guide/install/install_openshift_4.adoc
@@ -679,19 +679,10 @@ You can deploy Defenders to all nodes in an OpenShift cluster (master, infra, co
 OpenShift Container Platform automatically taints infra and master nodes
 These taints have the NoSchedule effect, which means no pod can be scheduled on them.
 
-To run the Defenders on these nodes, you can either remove the taint or add a toleration to the Defender DaemonSet.
+To run the Defenders on these nodes, add a toleration to the Defender DaemonSet.
 Once this is done, the Defender Daemonset will automatically be deployed to these nodes (no need to redeploy the Daemonset).
-Adjust the guidance in the following procedure according to your organization's deployment strategy.
 
-* *Option 1 - remove taint all nodes:*
-+
-  $ oc adm taint nodes --all node-role.kubernetes.io/master-
-
-* *Option 2 - remove taint from specific nodes:*
-+
-  $ oc adm taint nodes <node-name> node-role.kubernetes.io/master-
-
-* *Option 3 - add tolerations to the twistlock-defender-ds DaemonSet:*
+* *Add tolerations to the twistlock-defender-ds DaemonSet:*
 +
   $ oc edit ds twistlock-defender-ds -n twistlock
 +


### PR DESCRIPTION
We should not be recommending OpenShift maintainers to remove taints off of their master/infra nodes as this will impact licensing, API endpoints, and possibly other things.

