### PR TITLE
[PCSUP-10712] Defender version for Fargate

### DIFF
--- a/compute/admin_guide/install/install_defender/install_app_embedded_defender_fargate.adoc
+++ b/compute/admin_guide/install/install_defender/install_app_embedded_defender_fargate.adoc
@@ -305,6 +305,8 @@ Specify the registry type and pick the credential Prisma Cloud can use to access
 .. Click *Generate protected task*.
 
 .. Copy the updated task definition from the right-hand box, and use it to create a new task definition in AWS.
++
+The newly generated task definition always uses the version of Defender that matches the Console from which you are generating the task definition. The task definition includes a complete configuration, such as volumes, startup dependencies, entrypoint, healthchecks for its successful execution.  Therefore, manually changing the Defender version label in the task is not supported.
 
 
 [.task]


### PR DESCRIPTION
addressed the changes for Newly generated task definitions always use the latest (Console’s version) Defenders. Manually changing the Defender’s version label in the task is not supported

