### PR TITLE
[Compute Admin docs] appending the toc reference with *.adoc extension

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/registry_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/registry_scanning.adoc
@@ -2,7 +2,7 @@
 
 Configure Prisma Cloud to scan your registries.
 
-* xref:nexus-registry[Scan images in Sonatype Nexus Registry]
+* xref:nexus-registry.adoc[Scan images in Sonatype Nexus Registry]
 * xref:scan_alibaba_container_registry.adoc[Scan images in Alibaba Cloud Container Registry]
 * xref:scan_ecr.adoc[Scan images in Amazon EC2 Container Registry (ECR)]
 * xref:scan_acr.adoc[Scan images in Azure Container Registry (ACR)]
@@ -10,8 +10,8 @@ Configure Prisma Cloud to scan your registries.
 * xref:scan_google_artifact_registry.adoc[Scan images in Google Artifact Registry]
 * xref:scan_gcr.adoc[Scan images in Google Container Registry (GCR)]
 * xref:scan_harbor.adoc[Scan images in Harbor Registry]
-* xref:scan_ibm_cloud_container_registry[Scan images in IBM Cloud Container Registry]
-* xref:scan_artifactory[Scan images in Artifactory Docker Registry]
-* xref:scan_openshift[Scan Images in OpenShift integrated Docker Registry]
+* xref:scan_ibm_cloud_container_registry.adoc[Scan images in IBM Cloud Container Registry]
+* xref:scan_artifactory.adoc[Scan images in Artifactory Docker Registry]
+* xref:scan_openshift.adoc[Scan Images in OpenShift integrated Docker Registry]
 * xref:webhooks.adoc[Trigger Registry scans with webhooks]
 


### PR DESCRIPTION
## Description

The Registry scanning [TOC](https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-06/prisma-cloud-compute-edition-admin/vulnerability_management/registry_scanning0) link was broken for a few pages as the *.adoc extension was missing.

## Fix

Appended the reference with the *.adoc extension