### PR TITLE
[Code Sec AG] added GH info

### DIFF
--- a/code-security/admin_guide/book.yml
+++ b/code-security/admin_guide/book.yml
@@ -29,7 +29,10 @@ author: Prisma Cloud Team
 ditamap: code-security-admin
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-admin-code-security
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-admin-code-security
-
+repo:
+  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
+  branch: master
+  bookdir: code-security/admin_guide
 ---
 kind: chapter
 name: Get Started with Prisma Cloud Code Security


### PR DESCRIPTION
added the repo information to the book file
  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
  branch: master
  bookdir: code-security/admin_guide