### PR TITLE
[Compute AG]-[PCSUP-10975]

### DIFF
--- a/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
@@ -190,7 +190,7 @@ pipeline {
                 key: '',
                 logLevel: 'info',
                 podmanPath: '',
-                // The project field below is only applicable if you are using Prisma Cloud Compute Edition and have set up projects (multiple consoles) on Prisma Cloud. This field is not the name of the Jenkins pipeline.
+                // The project field below is only applicable if you are using Prisma Cloud Compute Edition and have set up projects (multiple consoles) on Prisma Cloud.
                 project: '',
                 resultsFile: 'prisma-cloud-scan-results.json',
                 ignoreImageBuildTime:true

--- a/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
@@ -162,6 +162,8 @@ Drill down into the build job, then click *Image Vulnerabilities* to see a detai
 +
 image::jenkins_dashboard_scan_results.png[width=800]
 +
+The *Projects* column in the CI scan results table displays the name of the Jenkins pipeline you created.
++
 Below is the sample code if you'd like to test an image for your Jenkins Pipeline for troubleshooting purposes:
 +
 The following example script builds a simple image, and runs the scan and publish steps.
@@ -188,7 +190,7 @@ pipeline {
                 key: '',
                 logLevel: 'info',
                 podmanPath: '',
-                // The project field below is the name of the Jenkins pipeline you created. This name will display in the CI scan results. 
+                // The project field below is only applicable if you are using Prisma Cloud Compute Edition and have set up projects (multiple consoles) on Prisma Cloud. This field is not the name of the Jenkins pipeline.
                 project: '',
                 resultsFile: 'prisma-cloud-scan-results.json',
                 ignoreImageBuildTime:true

--- a/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_pipeline_project.adoc
@@ -188,6 +188,7 @@ pipeline {
                 key: '',
                 logLevel: 'info',
                 podmanPath: '',
+                // The project field below is the name of the Jenkins pipeline you created. This name will display in the CI scan results. 
                 project: '',
                 resultsFile: 'prisma-cloud-scan-results.json',
                 ignoreImageBuildTime:true


### PR DESCRIPTION
Clarification that the the ‘project’ field that you see under the ci scan results will always present the jenkins job name.

