### PR TITLE
[Compute API Ref] Added endpoints for GH #41129

### DIFF
--- a/api/_topic_map.yml
+++ b/api/_topic_map.yml
@@ -1698,6 +1698,21 @@
       summary: Download twistcli for GNU/Linux
       description: !include ../descriptions/util/twistcli_get.md
 
+  /osx/twistcli:
+    get:
+      summary: Download twistcli for OS X
+      description: !include ../descriptions/util/osx_twistcli_get.md
+
+  /windows/twistcli.exe:
+    get:
+      summary: Download twistcli for Microsoft Windows
+      description: !include ../descriptions/util/windows_twistcli_get.md
+
+  /tas-tile:
+    get:
+      summary: Download VMware TAS tile for Prisma Cloud Compute
+      description: !include ../descriptions/util/twistlock_tas_tile_get.md
+
   /twistlock-jenkins-plugin.hpi:
     get:
       summary: Download Jenkins plugin for Prisma Cloud Compute

--- a/api/descriptions/util/osx_twistcli_get.md
+++ b/api/descriptions/util/osx_twistcli_get.md
@@ -1,0 +1,17 @@
+Downloads the twistcli binary executable for MacOS platforms.
+
+This endpoint maps to the **MacOS platform** hyperlink in **Manage > System > Utilities** in the Console UI.
+
+### cURL Request
+
+The following cURL command downloads the twistcli binary executable for MacOS platforms.
+
+```bash
+$ curl -k \
+  -u <USER> \
+  -L \
+  -o twistcli \
+  https://<CONSOLE>/api/v1/util/osx/twistcli
+```
+
+A successful response displays the status of the download.

--- a/api/descriptions/util/twistlock_jenkins_plugin_get.md
+++ b/api/descriptions/util/twistlock_jenkins_plugin_get.md
@@ -13,3 +13,5 @@ $ curl -k \
   -o twistlock-jenkins-plugin.hpi \
   https://<CONSOLE>/api/v1/util/twistlock-jenkins-plugin.hpi
 ```
+
+A successful response displays the status of the download.

--- a/api/descriptions/util/twistlock_tas_tile_get.md
+++ b/api/descriptions/util/twistlock_tas_tile_get.md
@@ -1,4 +1,4 @@
-Downloads the Prisma Cloud Compute Jenkins plugin.
+Downloads the VMware Tanzu Application Service tile for Prisma Cloud Compute.
 
 Although this endpoint is supported, no backwards compatibility is offered for it.
 
@@ -10,6 +10,6 @@ Refer to the following example cURL command:
 $ curl -k \
   -u <USER> \
   -L \
-  -o twistlock-jenkins-plugin.hpi \
-  https://<CONSOLE>/api/v1/util/twistlock-jenkins-plugin.hpi
+  -o twistlock-tile.pivotal \
+  "https://<CONSOLE>/api/v1/util/tas-tile"
 ```

--- a/api/descriptions/util/twistlock_tas_tile_get.md
+++ b/api/descriptions/util/twistlock_tas_tile_get.md
@@ -13,3 +13,5 @@ $ curl -k \
   -o twistlock-tile.pivotal \
   "https://<CONSOLE>/api/v1/util/tas-tile"
 ```
+
+A successful response displays the status of the download.

--- a/api/descriptions/util/windows_twistcli_get.md
+++ b/api/descriptions/util/windows_twistcli_get.md
@@ -1,0 +1,17 @@
+Downloads the twistcli binary executable for Windows platforms.
+
+This endpoint maps to the **Windows platform** hyperlink in **Manage > System > Utilities** in the Console UI.
+
+### cURL Request
+
+The following cURL command downloads the twistcli binary executable for Windows platforms.
+
+```bash
+$ curl -k \
+  -u <USER> \
+  -L \
+  -o twistcli.exe \
+  https://<CONSOLE>/api/v1/util/windows/twistcli.exe
+```
+
+A successful response displays the status of the download.

--- a/api/supported.cfg
+++ b/api/supported.cfg
@@ -34,6 +34,7 @@
 +/api/v1/settings/license,post
 +/api/v1/signup,post
 +/api/v1/util/prisma-cloud-jenkins-plugin.hpi,get
++/api/v1/util/tas-tile,get
 
 # Exclusions
 
@@ -44,7 +45,3 @@
 
 # Remove route serving GeoIP DB GH #40773
 -/api/v*/util/dbip-country-lite.mmdb,get
-
-# Under discussion, remove until advised otherwise
--/api/v*/util/osx/twistcli,get
--/api/v*/util/windows/twistcli.exe,get


### PR DESCRIPTION
After discussions with the engineering team, the missing endpoints are added.

This includes two more `v1` endpoints in addition to the existing four `v1` endpoints.

cc: @MayaShani and @Pubs-MV 

GH issue: https://spring.paloaltonetworks.com/twistlock/twistlock/issues/41129 

