### PR TITLE
[Compute AG] Removed Install ACS from book

### DIFF
--- a/compute/admin_guide/book_compute_edition.yml
+++ b/compute/admin_guide/book_compute_edition.yml
@@ -62,8 +62,8 @@ topics:
   file: install_amazon_ecs.adoc
 - name: Alibaba Cloud Container Service for Kubernetes (ACK)
   file: install-ack.adoc
-- name: Azure Container Service (ACS) with Kubernetes
-  file: install-acs.adoc
+# - name: Azure Container Service (ACS) with Kubernetes
+# file: install-acs.adoc
 - name: Azure Kubernetes Service (AKS)
   file: install-aks.adoc
 - name: Amazon Elastic Kubernetes Service (EKS)

--- a/compute/admin_guide/book_prisma_cloud.yml
+++ b/compute/admin_guide/book_prisma_cloud.yml
@@ -62,8 +62,8 @@ topics:
   file: install_amazon_ecs.adoc
 - name: Alibaba Cloud Container Service for Kubernetes (ACK)
   file: install-ack.adoc
-- name: Azure Container Service (ACS) with Kubernetes
-  file: install-acs.adoc
+#- name: Azure Container Service (ACS) with Kubernetes
+#  file: install-acs.adoc
 - name: Azure Kubernetes Service (AKS)
   file: install-aks.adoc
 - name: Amazon Elastic Kubernetes Service (EKS)

--- a/compute/admin_guide/install/getting_started.adoc
+++ b/compute/admin_guide/install/getting_started.adoc
@@ -95,7 +95,6 @@ endif::compute_edition[]
 We've tested and validated the install on:
 
 * https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html[Amazon Elastic Kubernetes Service (Amazon EKS)]
-* https://docs.microsoft.com/en-us/azure/container-service/kubernetes/[Azure Container Service with Kubernetes]
 * https://docs.microsoft.com/en-us/azure/aks/[Azure Kubernetes Service (AKS)]
 * https://cloud.google.com/kubernetes-engine/docs/[Google Kubernetes Engine (GKE)]
 * https://cloud.ibm.com/docs/containers?topic=containers-getting-started[IBM Kubernetes Service (IKS)]


### PR DESCRIPTION
ACS is not inlcuded in the system reqs and we had a note in the ACS install topic that said " Microsoft will retire ACS as a standalone service on January 31, 2020.".

