### PR TITLE
[Compute AG] Update source spreadsheet for perms table

### DIFF
--- a/compute/admin_guide/configure/permissions.adoc
+++ b/compute/admin_guide/configure/permissions.adoc
@@ -7,19 +7,19 @@ The following tables list the permissions required for each of Compute's protect
 
 [format=csv, options="header"]
 |===
-include::https://docs.google.com/spreadsheets/d/e/2PACX-1vSXjL--cSdZbGWeCEraN4Zaaob6VZDF56I1ga3h7jx1Fuz77fst0ttMLSYXAhSgVulr85EHGHKzwIEY/pub?output=csv[]
+include::https://docs.google.com/spreadsheets/d/e/2PACX-1vQGxhsOAAuj13OSYtAJCzU2CQ5G12FZxro0vHaqf8Tzcm96ZCxhxAW2jeT3__HfvliAMXUwGG_Hly8g/pub?output=csv&gid=338970097[]
 |===
 
 === GCP
 
 [format=csv, options="header"]
 |===
-include::https://docs.google.com/spreadsheets/d/e/2PACX-1vSXjL--cSdZbGWeCEraN4Zaaob6VZDF56I1ga3h7jx1Fuz77fst0ttMLSYXAhSgVulr85EHGHKzwIEY/pub?output=csv&gid=1544908704[]
+include::https://docs.google.com/spreadsheets/d/e/2PACX-1vQGxhsOAAuj13OSYtAJCzU2CQ5G12FZxro0vHaqf8Tzcm96ZCxhxAW2jeT3__HfvliAMXUwGG_Hly8g/pub?output=csv&gid=942713996[]
 |===
 
 === Azure
 
 [format=csv, options="header"]
 |===
-include::https://docs.google.com/spreadsheets/d/e/2PACX-1vSXjL--cSdZbGWeCEraN4Zaaob6VZDF56I1ga3h7jx1Fuz77fst0ttMLSYXAhSgVulr85EHGHKzwIEY/pub?output=csv&gid=1020386260[]
+include::https://docs.google.com/spreadsheets/d/e/2PACX-1vQGxhsOAAuj13OSYtAJCzU2CQ5G12FZxro0vHaqf8Tzcm96ZCxhxAW2jeT3__HfvliAMXUwGG_Hly8g/pub?output=csv&gid=0[]
 |===


### PR DESCRIPTION
Update the permissions tables to point to the source of truth spreadsheet.

It was previously pointing to a privately maintained mirror copy.