### PR TITLE
Added a note about empty status field on /stats/vulnerabilities

### DIFF
--- a/compute/rn/release-information/release-notes-22-06.adoc
+++ b/compute/rn/release-information/release-notes-22-06.adoc
@@ -444,13 +444,16 @@ The data for each CVE, such as impacted packages, highest severity, and so on, i
 
 Also, the impacted resources and distribution counts are not retrieved and are returned as zero when you apply filters or are assigned with specific collections or accounts.
 
+One more change in this API endpoint is that the value of the `status` field will now be empty. In the context of a CVE, there can be multiple fix statuses, depending on the impacted package. Therefore, providing a fix status per CVE is incorrect and was removed. 
+To get the right fix status according to the package, use additional endpoint to fetch the resources impacted by the CVE and their details.
+
 ==== GET /stats/vulnerabilities/impacted-resources
 
 // #37351, #37356
 Introduces new optional query parameters such as *pagination* and *resource type* to the existing API endpoint.
 To enable backward compatibility, if you don’t use these optional query parameters, the API response will display results without pagination and registry images, and similar to the response in the previous releases (Joule or earlier).
 
-*Note*- Make sure to update your scripts before the Newton release. Starting with the Newton release, the API response will no longer support requests without the pagination and resource type query parameters.
+*Note:* Make sure to update your scripts before the Newton release. Starting with the Newton release, the API response will no longer support requests without the pagination and resource type query parameters.
 
 ==== GET /stats/vulnerabilities/download
 


### PR DESCRIPTION
In Kepler, we changed the vulnerability explorer APIs.
As a part of it, in the /stats/vulnerabilities API we will now send the status field empty. It was incorrect to send from the first place because it can be different per package. 

Following https://redlock.atlassian.net/browse/PCSUP-11162
