### PR TITLE
[Compute Admin] Update twistcli_scan_images.adoc

### DIFF
--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -145,7 +145,8 @@ Publishes scan results to the Console (default: --publish=true)
 
 
 `--tarball`::
-Boolean flag that specifies the image to scan is a tar archive. Actions taken by the tarball scanning operation require enhanced priviledges and must be ran as sudo or as the root user.
+Boolean flag that specifies the image to scan is a tar archive. 
+The tarball scan requires enhanced privileges, and must be executed as sudo or as a root user.
 Prisma Cloud supports tar archives in the https://github.com/moby/moby/tree/00d8a3bb516ad1e14c56ccdfeb70736bbeb0ba49/image/spec[Docker Image Specification] format, v1.1 and later.
 The `tarball` option is supported on Linux only; neither macOS nor Windows versions of twistcli offer it.
 +
@@ -154,8 +155,6 @@ The `--tarball` option is simply a boolean flag.
 It doesn't accept a corresponding value (e.g. a path to a tarball).
 For clarity, see the following examples:
 +
-
-
 Correct usage:
 +
   ./twistcli --tarball --user ted image.tar

--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -145,7 +145,7 @@ Publishes scan results to the Console (default: --publish=true)
 
 
 `--tarball`::
-Boolean flag that specifies the image to scan is a tar archive.
+Boolean flag that specifies the image to scan is a tar archive. Actions taken by the tarball scanning operation require enhanced priviledges and must be ran as sudo or as the root user.
 Prisma Cloud supports tar archives in the https://github.com/moby/moby/tree/00d8a3bb516ad1e14c56ccdfeb70736bbeb0ba49/image/spec[Docker Image Specification] format, v1.1 and later.
 The `tarball` option is supported on Linux only; neither macOS nor Windows versions of twistcli offer it.
 +
@@ -154,6 +154,8 @@ The `--tarball` option is simply a boolean flag.
 It doesn't accept a corresponding value (e.g. a path to a tarball).
 For clarity, see the following examples:
 +
+
+
 Correct usage:
 +
   ./twistcli --tarball --user ted image.tar

--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -148,10 +148,8 @@ Publishes scan results to the Console (default: --publish=true)
 Boolean flag that specifies the image to scan is a tar archive. 
 The tarball scan requires enhanced privileges, and must be executed as sudo or as a root user.
 Prisma Cloud supports tar archives in the https://github.com/moby/moby/tree/00d8a3bb516ad1e14c56ccdfeb70736bbeb0ba49/image/spec[Docker Image Specification] format, v1.1 and later.
-The `tarball` option 
 
-* is supported on Linux only; macOS and Windows versions of twistcli do not support it.
-* checks for vulnerabilities only; compliance scan is not supported.
+The `tarball` option is supported on Linux only; macOS and Windows versions of twistcli do not support it.
 
 The last parameter in the twistcli command should always be the path to the tarball.
 The `--tarball` option is simply a boolean flag.

--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -148,21 +148,24 @@ Publishes scan results to the Console (default: --publish=true)
 Boolean flag that specifies the image to scan is a tar archive. 
 The tarball scan requires enhanced privileges, and must be executed as sudo or as a root user.
 Prisma Cloud supports tar archives in the https://github.com/moby/moby/tree/00d8a3bb516ad1e14c56ccdfeb70736bbeb0ba49/image/spec[Docker Image Specification] format, v1.1 and later.
-The `tarball` option is supported on Linux only; neither macOS nor Windows versions of twistcli offer it.
-+
+The `tarball` option 
+
+* is supported on Linux only; macOS and Windows versions of twistcli do not support it.
+* checks for vulnerabilities only; compliance scan is not supported.
+
 The last parameter in the twistcli command should always be the path to the tarball.
 The `--tarball` option is simply a boolean flag.
 It doesn't accept a corresponding value (e.g. a path to a tarball).
 For clarity, see the following examples:
-+
-Correct usage:
-+
-  ./twistcli --tarball --user ted image.tar
-+
-Incorrect usage:
-+
-  ./twistcli --tarball image.tar --user ted
 
+Correct usage:
+----
+  ./twistcli --tarball --user ted image.tar
+----
+Incorrect usage:
+----
+  ./twistcli --tarball image.tar --user ted
+----
 
 ==== Return value
 


### PR DESCRIPTION
Twistcli --tarball utilizes chroot, which is a sudo or root user level operation in Linux . Therefore, we need to specify this so customers will know to expect this behavior . 

@mklambert for contributions to this PR .

Non-PCSUP

