### PR TITLE
Correcting the Trusted Executable Feed description

### DIFF
--- a/compute/admin_guide/configure/custom_feeds.adoc
+++ b/compute/admin_guide/configure/custom_feeds.adoc
@@ -78,35 +78,38 @@ It is also used immediately by the runtime defense file system sensor, which ass
 [.task]
 === Create a list of trusted executables
 
-The Trusted Executable Feed is a mechanism to address potential misidentification of legitimate files as malware. You can add to the feed signatures of binaries that have been incorrectly categorized as malicious by the file system based malware runtime protection. 
+The trusted executable list is a mechanism to address potential misidentification of legitimate files as malware. When you add signatures of binaries to this list, it enables you to ensure that a legitimate binary or a process created from a legitimate binary is not potentially identified as malicious by runtime defense rules that check for file system based malware. 
 
-NOTE: The Trusted Executable Feed does not apply to other runtime detection capabilities (e.g., process runtime protection). To exclude files from other runtime detection capabilities use the rule allowed list. Check the relevant xref:../runtime_defense/runtime_defense.adoc[runtime defense section] for more details. 
-
-You can specify one entry at a time, or do a bulk upload from a CSV file.
-The maximum file size is 20MB.
+The trusted executable list does not apply to other runtime defense capabilities, such as process runtime protection. To exclude files from other runtime detection capabilities use the allowed list in the xref:../runtime_defense/runtime_defense.adoc[runtime defense section]. 
 
 NOTE: Malware scanning and detection is supported for Linux container images and hosts only.
 Windows containers and hosts are not supported.
-
-The first line in your CSV file must be a header record that contains the field names.
-For trusted executables data, specify the MD5, followed by text description that allows you to identify why the MD5 was marked as trusted in the future. 
-Specify one entry per line.
-For example:
-
-  md5,name
-  194836fbe0f121a25b145e55e80cef22,legitimate binary built in house
-  0aeb0cac186a81a6ac45776d6b56dd70,test file
-  33cc273ae3aa8bce6a22c92e7d11f63a,benign file
 
 [.procedure]
 . Open Console.
 
 . Go to *Manage > System > Custom Feeds*.
 
-. Click *Upload Malware Data*, and either click *Add* or *Import CSV*.
+. Choose how to add the MD5 values for the trusted executables.
 +
-Your custom malware data is used in all subsequent image scans.
+The MD5 hashes you add are used in all subsequent image scans.
 It is also used immediately by the runtime defense file system sensor, which assesses all writes to the host and container file system.
+
+.. For *Add MD5*, you can manually add one entry at a time.
+.. For *Import CSV*, you can bulk upload from a CSV file.
++ 
+The maximum file size is 20MB.
++
+The first line in your CSV file must be a header record that contains the field names.
++
+Specify one entry per line. Each entry must include the MD5, followed by a good description to identify why the MD5 is trusted. 
++
+For example:
++
+  md5,name
+  194836fbe0f121a25b145e55e80cef22,legitimate binary built in house
+  0aeb0cac186a81a6ac45776d6b56dd70,test file
+  33cc273ae3aa8bce6a22c92e7d11f63a,benign file
 
 . Review the default rule.
 +

--- a/compute/admin_guide/configure/custom_feeds.adoc
+++ b/compute/admin_guide/configure/custom_feeds.adoc
@@ -68,7 +68,7 @@ For example:
 [.procedure]
 . Open Console.
 
-. Go to *Manage > System > Malware signatures*.
+. Go to *Manage > System > Custom feeds > Malware signatures*.
 
 . Click *Upload Malware Data*, and either click *Add* or *Import CSV*.
 +
@@ -78,7 +78,7 @@ It is also used immediately by the runtime defense file system sensor, which ass
 [.task]
 === Create a list of trusted executables
 
-The trusted executable list is a mechanism to address potential misidentification of legitimate files as malware. When you add signatures of binaries to this list, it enables you to ensure that a legitimate binary or a process created from a legitimate binary is not potentially identified as malicious by runtime defense rules that check for file system based malware. 
+The trusted executable list is a mechanism to address potential misidentification of legitimate files as malware. When you add signatures of binaries to this list, it enables you to ensure that a legitimate binary is not potentially identified as malicious by file system based defense capability in runtime rules. 
 
 The trusted executable list does not apply to other runtime defense capabilities, such as process runtime protection. To exclude files from other runtime detection capabilities use the allowed list in the xref:../runtime_defense/runtime_defense.adoc[runtime defense section]. 
 
@@ -88,11 +88,11 @@ Windows containers and hosts are not supported.
 [.procedure]
 . Open Console.
 
-. Go to *Manage > System > Custom Feeds*.
+. Go to *Manage > System > Custom Feeds > Trusted executables*.
 
-. Choose how to add the MD5 values for the trusted executables.
+. Choose how to add the MD5 hashes for trusted executables.
 +
-The MD5 hashes you add are used in all subsequent image scans.
+The MD5 hashes you add to custom malware feeds are used in all subsequent image scans.
 It is also used immediately by the runtime defense file system sensor, which assesses all writes to the host and container file system.
 
 .. For *Add MD5*, you can manually add one entry at a time.

--- a/compute/admin_guide/configure/custom_feeds.adoc
+++ b/compute/admin_guide/configure/custom_feeds.adoc
@@ -78,7 +78,9 @@ It is also used immediately by the runtime defense file system sensor, which ass
 [.task]
 === Create a list of trusted executables
 
-If a legitimate binary or a process created from a legitimate binary is incorrectly identified as malicious by any of the runtime detection capabilities, you can add the signature of the binary to a list of trusted executables signatures and ensure that it will not be inspected by any runtime capabilities. 
+The Trusted Executable Feed is a mechanism to address potential misidentification of legitimate files as malware. You can add to the feed signatures of binaries that have been incorrectly categorized as malicious by the file system based malware runtime protection. 
+
+NOTE: The Trusted Executable Feed does not apply to other runtime detection capabilities (e.g., process runtime protection). To exclude files from other runtime detection capabilities use the rule allowed list. Check the relevant xref:../runtime_defense/runtime_defense.adoc[runtime defense section] for more details. 
 
 You can specify one entry at a time, or do a bulk upload from a CSV file.
 The maximum file size is 20MB.


### PR DESCRIPTION
The Trusted Executable Feed currently states that it applies to all runtime capabilities. This is incorrect as it only applies to the file system runtime protection. Fixed the description and added the correct way of excluding binaries for other capabilities.

