### PR TITLE
[Admin Guide - Serverless Defender]: Rearrange maven *.pom file

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -213,18 +213,6 @@ The steps for embedding Serverless Defender differ depending on the build tool.
 
 . Create a file called defender-<version>-pom.xml in the same location of the jar (change the version tag based on your version):
 
-.. Define the internal (local) repository in the `*pom.xml` file:
-
-  <project>
-      <repositories>
-          <repository>
-              <id>twistlock-internal</id>
-              <name>twistlock</name>
-              <url>file://${project.basedir}/twistlock</url>
-          </repository>
-       ...
-  </project>
-
 .. Enter the package details and artifact id in the `*pom.xml` file:
 
   <project>
@@ -313,6 +301,17 @@ Usually the shade plugin is used in AWS to include packages to standalone JARs, 
       </resources>
       ...
     </build>
++
+      <!-- Define the internal (local) repository in the `*pom.xml` file: -->
+      <project>
+        <repositories>
+          <repository>
+            <id>twistlock-internal</id>
+            <name>twistlock</name>
+            <url>file://${project.basedir}/twistlock</url>
+          </repository>
+       ...
+      </project>
 +
     <!-- Add Twistlock package reference -->
     <dependencies>


### PR DESCRIPTION
## Description

Move the internal repository code to Maven section as it's only applicable for Maven and not Gradle. Gradel uses the `build.gradle` file.