### PR TITLE
[Moved to private repo]: Update on Maven auto subdirectory structure

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -181,7 +181,7 @@ Even though the Context parameter is optional for unprotected functions, it's ma
 Prisma Cloud supports Java 8 and Java 11.
 
 [.procedure]
-. Open Compute Console, and go to *Manage > Defenders > Deploy > Defenders > Single Defender*.
+. Open Compute Console, and go to *Manage > Defenders > Deployed Defenders > Manual Deploy > Single Defender*.
 
 ifdef::compute_edition[]
 . Choose the DNS name or IP address Serverless Defender uses to connect to Console.
@@ -191,7 +191,9 @@ ifdef::prisma_cloud[]
 . The DNS name Serverless Defender uses to connect to your Compute Console is prepopulated for you.
 endif::prisma_cloud[]
 
-. In *Choose Defender type*, select *Serverless Defender - AWS*.
+. In *Defender type*, select *Serverless Defender - AWS*.
+
+. Select the name that Defender will use to connect to this Console.
 
 . In *Runtime*, select *Java*.
 
@@ -203,6 +205,7 @@ The steps for embedding Serverless Defender differ depending on the build tool.
 
 . Unzip the Serverless Defender bundle into your working directory.
 
+////
 . Inside the `twistlock` directory (the root directory in the zip), create a new sub-directory with the following structure: `com/twistlock/serverless/defender/<version>/`. For example, for version 22.06.286:
 
   mkdir -p com/twistlock/serverless/defender/22.06.286
@@ -212,8 +215,8 @@ The steps for embedding Serverless Defender differ depending on the build tool.
 . Rename the *.jar file to the convention: defender-<version>.jar (e.g. defender-22.06.286.jar).
 
 . Create a file called defender-<version>-pom.xml in the same location of the jar (change the version tag based on your version):
-
-.. Enter the package details and artifact id in the `*pom.xml` file:
+////
+.. Enter the package details and artifact id in the `defender-<version>.pom` file:
 
   <project>
     <modelVersion>4.0.0</modelVersion>
@@ -252,7 +255,7 @@ public class ... implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
 
 .. *Maven*
 +
-Update your `*pom.xml` file.
+Update your `*.pom` xml file.
 Don't create new sections for the Prisma Cloud configurations.
 Just update existing sections.
 For example, don't create a new <plugins> section if one exists already.
@@ -302,7 +305,7 @@ Usually the shade plugin is used in AWS to include packages to standalone JARs, 
       ...
     </build>
 +
-      <!-- Define the internal (local) repository in the `*pom.xml` file: -->
+      <!-- Define the internal (local) repository in the `*.pom` xml file: -->
       <project>
         <repositories>
           <repository>
@@ -325,7 +328,7 @@ Usually the shade plugin is used in AWS to include packages to standalone JARs, 
     ...
   </project>
 
-.. Create an assembly.xml file, which packs all dependencies in a standalone JAR.
+.. Create an `assembly.xml` file, which packs all dependencies in a standalone JAR.
 
   <assembly>
     <id>twistlock-protected</id>


### PR DESCRIPTION
With Lagrange, the Serverless Defender package now includes the default Maven repo subdirectory and the user no longer has to create the dir structure.
Discarded step: `mkdir -p com/twistlock/serverless/defender/22.xx.xxx`.