### PR TITLE
[Code Security AG] removed link in UI path

### DIFF
--- a/code-security/admin_guide/scan-monitor/software-composition-analysis/license-compliance-in-sca.adoc
+++ b/code-security/admin_guide/scan-monitor/software-composition-analysis/license-compliance-in-sca.adoc
@@ -51,7 +51,7 @@ Suppression types are of two kinds:
 
 [.procedure]
 
-. Access *Code Security > Projects* and then select *Category - Licenses* filter.
+. Access *Code Security > Projects* and then select *Category* - *Licenses*.
 +
 image::sca-24.png[width=800]
 
@@ -73,7 +73,7 @@ You can optionally add an *Expiration Date* for the suppression and then select 
 +
 image::sca-28.png[width=600]
 
-.. Select the *Suppression Type*.
+.. Select *Suppression Type*.
 +
 You can choose to suppress a policy violation from:
 +
@@ -82,7 +82,7 @@ You can choose to suppress a policy violation from:
 +
 image::sca-29.png[width=600]
 
-.. Select License types.
+.. Select *License types*.
 +
 License types are subjective to the open source package, where you can define the suppression only to the identified license.
 +

--- a/code-security/admin_guide/scan-monitor/software-composition-analysis/software-composition-analysis.adoc
+++ b/code-security/admin_guide/scan-monitor/software-composition-analysis/software-composition-analysis.adoc
@@ -12,19 +12,19 @@ The SCA vulnerabilities scan results include:
 
 * *Bill of Materials (BOM)*
 +
-Bill of materials (BOM) or xref:../development-pipelines/sbom-generation.adoc[software bill of materials (SBOM)] is a contextualized inventory of open source packages and third-party components your source code utilizes. SBOM includes information on versions, licenses and vulnerabilities of the components that comprise your application's source code, helping you make legal and risk assessments of your application. On the Prisma Cloud console you can view the SBOM reports on *Code Security > xref:../development-pipelines/development-pipelines.adoc[Development Pipelines]* where the reports are specific to runtime resources.
+Bill of materials (BOM) or xref:../development-pipelines/sbom-generation.adoc[software bill of materials (SBOM)] is a contextualized inventory of open source packages and third-party components your source code utilizes. SBOM includes information on versions, licenses and vulnerabilities of the components that comprise your application's source code, helping you make legal and risk assessments of your application. On the Prisma Cloud console you can view the SBOM reports on *Code Security > Development Pipelines* where the reports are specific to runtime resources.
 
 * *Dependency Graph*
 +
 Open source software often includes packages with dependencies, thus creating an endless loop of complex interdependencies leading to a black box of security vulnerabilities.
 A dependency graph analyzes these interdependencies while also identifying direct dependencies between the packages. Information on direct dependency helps you in identifying where there are vulnerabilities outside of the root dependency enabling you to make informed security decisions.
-On the Prisma Cloud console, this graph is best visualized on *Code Security > xref:../supply-chain-security.adoc[Supply Chain]* where every sub-dependency has contextualized information available on xref:../monitor-fix-issues-in-scan.adoc[Resource Explorer.]
+On the Prisma Cloud console, this graph is best visualized on *Code Security > Supply Chain* where every sub-dependency has contextualized information available on xref:../monitor-fix-issues-in-scan.adoc[Resource Explorer.]
 
 * *License compliance*
 +
 For every available open source software, there are licenses that define how to use, modify and enhance the open source code. The license grants user permissions and rights to repurpose the code into another code. Prisma Cloud scans for compliant licenses using industry standards to identify any restrictive licenses as violations.
 There are two ways you can identify license vulnerabilities on Prisma Cloud.
-Firstly, during code development you can run a Checkov scan and secondly, on the Prisma Cloud console from Code Security > Projects. On the console using the contextualized information for license issues on xref:../monitor-fix-issues-in-scan.adoc[Resource Explorer] you can make an informed decision to suppress the violation. For more information see xref:license-compliance-in-sca.adoc[Licensing in Software Composition Analysis (SCA)].
+Firstly, during code development you can run a Checkov scan and secondly, on the Prisma Cloud console from *Code Security > Projects*. On the console using the contextualized information for license issues on xref:../monitor-fix-issues-in-scan.adoc[Resource Explorer] you can make an informed decision to suppress the violation. For more information see xref:license-compliance-in-sca.adoc[Licensing in Software Composition Analysis (SCA)].
 
 * *Remediation*
 +
@@ -83,7 +83,7 @@ image::sca-2.png[width=600]
 
 * *Projects*
 +
-During periodic scans on Prisma Cloud the SCA scan results are updated and contextualized for monitoring and remediating package vulnerabilities identified in the source code on *Code Security > Projects*. To view results exclusively for SCA scan results enable filter *Category > Vulnerability*.
+During periodic scans on Prisma Cloud the SCA scan results are updated and contextualized for monitoring and remediating package vulnerabilities identified in the source code on *Code Security > Projects*. To view results exclusively for SCA scan results enable *Category* - *Vulnerability*.
 The contextualized information for each package is available on the xref:../monitor-fix-issues-in-scan.adoc[Resource Explorer].
 The scan results outline direct and sub-dependency packages in the source code to help you make informed decisions for each type of package.
 In this example, you see the scan result of a direct dependency package with contextualized information of a package vulnerability in *Resource Explorer > Errors*.
@@ -115,7 +115,7 @@ For identified package vulnerabilities, especially packages with direct dependen
 
 . Access *Code Security > Projects* and then browse for a specific repository.
 
-. Select *Category - Vulnerability* filter to view SCA errors.
+. Select *Category* - *Vulnerability* to view SCA errors.
 
 . Select the package to remediate.
 +
@@ -146,7 +146,7 @@ image::sca-10.png[width=600]
 
 ==== Supply Chain
 
-As a remediation for sub-dependent packages, you can view and analyze the dependency tree on *Code Security > xref:../supply-chain-security.adoc[Supply Chain]*. If the packages have direct dependencies irrespective of their placement in the dependency tree, Prisma Cloud offers solutions to these vulnerabilities. Here you can also choose to remediate the vulnerability by submitting a single PR (Pull Request) for all packages with vulnerabilities on the graph.
+As a remediation for sub-dependent packages, you can view and analyze the dependency tree on *Code Security > Supply Chain*. If the packages have direct dependencies irrespective of their placement in the dependency tree, Prisma Cloud offers solutions to these vulnerabilities. Here you can also choose to remediate the vulnerability by submitting a single PR (Pull Request) for all packages with vulnerabilities on the graph.
 
 [.procedure]
 
@@ -168,7 +168,7 @@ Every identified vulnerability in an SCA scan can be suppressed on the console f
 
 [.procedure]
 
-. Access *Code Security > Projects* and then select *Category - Vulnerability* filter.
+. Access *Code Security > Projects* and then select *Category* - *Vulnerability*.
 
 . Select the vulnerability to suppress.
 +


### PR DESCRIPTION
Have removed UI path links in the 2 adocs and updated the style to maintain consistency. 

- software-composition-analysis.adoc
- license-compliance-in-sca.adoc