### PR TITLE
Update auto_defend_host.adoc

### DIFF
--- a/compute/admin_guide/install/install_defender/auto_defend_host.adoc
+++ b/compute/admin_guide/install/install_defender/auto_defend_host.adoc
@@ -135,7 +135,7 @@ The following sections describe the minimum requires to auto-defend hosts on GCP
 
 ===== Storage Buckets
 
-Prisma cloud auto creates a temporary storage bucket named 'prisma-bucket' in the region you selected in the auto-defend rule.
+Prisma cloud auto creates a temporary storage bucket in the region you selected in the auto-defend rule. The bucket is named 'prisma-defender-bucket-<hash>' where <hash> is a randomly generated string, e.g., 'prisma-defender-bucket-346a7e425d344c8a7dd9ce75da674970'.
 The Prisma defender installation script 'prisma-defender-script.sh' is stored in the bucket.
 
 The service account user needs permissions to be able to create and delete the bucket.

--- a/compute/admin_guide/install/install_defender/auto_defend_host.adoc
+++ b/compute/admin_guide/install/install_defender/auto_defend_host.adoc
@@ -135,7 +135,7 @@ The following sections describe the minimum requires to auto-defend hosts on GCP
 
 ===== Storage Buckets
 
-Prisma cloud auto creates a temporary storage bucket in the region you selected in the auto-defend rule. The bucket is named 'prisma-defender-bucket-<hash>' where <hash> is a randomly generated string, e.g., 'prisma-defender-bucket-346a7e425d344c8a7dd9ce75da674970'.
+Prisma cloud auto creates a temporary storage bucket in the region you selected for the auto-defend rule. The bucket is named 'prisma-defender-bucket-<hash>' where <hash> is a randomly generated string, e.g., 'prisma-defender-bucket-346a7e425d344c8a7dd9ce75da674970'.
 The Prisma defender installation script 'prisma-defender-script.sh' is stored in the bucket.
 
 The service account user needs permissions to be able to create and delete the bucket.


### PR DESCRIPTION
Change the documented prefix of the name of the temporary GCP bucket created in GCP auto-deploy to "prisma-defender-bucket".

