### PR TITLE
Support for local dependencies in GCP

### DIFF
--- a/compute/admin_guide/vulnerability_management/serverless_functions.adoc
+++ b/compute/admin_guide/vulnerability_management/serverless_functions.adoc
@@ -234,6 +234,8 @@ cloudfunctions.operations.list
 cloudfunctions.runtimes.list
 ----
 
+NOTE: Prisma Cloud currently supports scanning functions that are packaged with local depenendencies.
+
 === Scanning functions at build time with twistcli
 
 You can also use the `twistcli` command line utility to scan your serverless functions.


### PR DESCRIPTION
Documented that Prisma Cloud currently only supports scanning functions that were packaged with local dependencies.