### PR TITLE
Documents are contradictory for Update scan_acr.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/scan_acr.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/scan_acr.adoc
@@ -34,7 +34,7 @@ Leave this field blank to scan all images, regardless of their tag.
 
 .. In the *Credential* field, configure how Prisma Cloud authenticates with ACR.
 +
-Select a credential from the drop-down list.
+You need to create a Service Principal with Reader Role and scoped for the subscription in order to scan the registry. You cannot use the Cloud Accounts added to Prisma Cloud even though they have the correct permissions. For more information see [credentials_store](/authentication/credentials_store)
 +
 If there are no credentials in the list, click *Add new* to xref:../../authentication/credentials_store.adoc#_azure_service_principal[create an Azure credential] where the service principal authenticates with a password.
 +


### PR DESCRIPTION
The current version says to use credentials from the pull down menu, however you cannot you Prisma Cloud credentials to authenticate to an Azure Container Registry. This is explained in the authentication section but if you come straight to how to configure your registry you will not get that information. Instead you will get frustrated.

