### PR TITLE
[CWP-36091 and CWP-41843]: Updated supported.cfg and added information for the missing VM Image Scan

### DIFF
--- a/api/_topic_map.yml
+++ b/api/_topic_map.yml
@@ -1383,6 +1383,10 @@
   displayName: VM image scan reports 
   description: !include ../descriptions/vms/vms.md
   
+  get:
+    summary: Get VM Image Scan Results
+    description: !include ../descriptions/vms/get.md
+
   /labels:
     get:
       summary: Get VM Image Tags

--- a/api/descriptions/vms/download_get.md
+++ b/api/descriptions/vms/download_get.md
@@ -1,6 +1,6 @@
-Downloads all VM image scan reports in CSV format.
+Returns all VM image scan reports in CSV format.
 
-This endpoint maps to the CSV hyperlink in **Monitor > Vulnerabilities > Hosts > VM images** in the Console UI.
+**Note**: This endpoint maps to the table in **Monitor > Vulnerabilities > Hosts > VM images > CSV** in the Prisma Cloud Compute.
 
 ### cURL Request
 

--- a/api/descriptions/vms/get.md
+++ b/api/descriptions/vms/get.md
@@ -1,17 +1,59 @@
-Retrieves all VM image scan reports.
+Returns all VM image scan reports.
 
-This endpoint maps to the table in **Monitor > Vulnerabilities > Hosts > VM images** in the Console UI.
+**Note**: This endpoint maps to the table in **Monitor > Vulnerabilities > Hosts > VM images** in the Prisma Cloud Compute.
 
 ### cURL Request
 
-The following cURL command retrieves all VM image scan reports.
+Refer to the following example cURL command that retrieves all VM image scan reports:
 
 ```bash
 $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>/api/v1/vms \
+  "https://<CONSOLE>/api/v<VERSION>/vms"
 ```
 
-A successful response returns the scan reports.
+### cURL Response
+
+Refer to the following example VM scan report:
+
+```
+{
+    "_id": "2226875301309860442",
+    "type": "vm",
+    "hostname": "",
+    "scanTime": "2022-12-01T18:08:15.299Z",
+    "binaries": [],
+    "Secrets": [],
+    "startupBinaries": [],
+    "osDistro": "redhat",
+    "osDistroVersion": "7",
+    "osDistroRelease": "RHEL7",
+    "distro": "CentOS Linux release 7.9.2009 (Core)",
+    "packages": [
+      {
+        "pkgsType": "package",
+        "pkgs": [
+          {
+            "version": "0.100-7.el7",
+            "name": "dbus-glib",
+            "cveCount": 8,
+            "license": "AFL and GPLv2+",
+            "layerTime": 0
+          },
+          {
+            "version": "2.02-0.87.el7.centos.7",
+            "name": "grub2-common",
+            "cveCount": 184,
+            "license": "GPLv3+",
+            "layerTime": 0
+          }
+        ...
+        ...
+        ...
+        ]
+      }
+    ]
+}
+```

--- a/api/descriptions/vms/labels_get.md
+++ b/api/descriptions/vms/labels_get.md
@@ -11,3 +11,17 @@ $ curl -k \
   -X GET \
   "https://<CONSOLE>/api/v<VERSION>/vms/labels"
 ```
+### cURL Response
+
+Refer to the following example response:
+
+```
+[
+  "gcp:vmscan",
+  "with_pulled_images:true",
+  "test-linux-key-2:test-linux-value-2",
+  "test-linux-key-1:test-linux-value-1",
+  "Name:user-test-b"
+]
+
+```

--- a/api/descriptions/vms/names_get.md
+++ b/api/descriptions/vms/names_get.md
@@ -12,3 +12,21 @@ $ curl -k \
   -H 'Content-Type: application/json' \
   "https://<CONSOLE>/api/v<VERSION>/vms/names"
 ```
+
+### cURL Response
+
+Refer to the following example response:
+
+```
+[
+  "new-auto-images-cen7-dock",
+  "ubuntu-pro-2004-focal-v20210720",
+  "user-encrypted2",
+  "ubuntu-20.04-lts:1.0.0",
+  "user-test-b",
+  "user-ubuntu-image-scan1",
+  "Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202110260",
+  "ubuntu-20.04-lts"
+]
+
+```

--- a/api/descriptions/vms/vms.md
+++ b/api/descriptions/vms/vms.md
@@ -1,2 +1,8 @@
-Scan VM images.
-Prisma Cloud currently supports Amazon Machine Images (AMIs) only.
+Scan VM images in AWS, Azure, and GCP for vulnerabilities.
+
+Prisma Cloud can scan the following VM images:
+* AWS: Linux Amazon Machine Images (AMIs)
+* Azure: Managed, Gallery and Marketplace images
+* GCP: Public and Custom images (including Premium images)
+
+For more information, see [Configure VM Image Scanning](https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute/vulnerability_management/vm_image_scanning)

--- a/api/supported.cfg
+++ b/api/supported.cfg
@@ -46,5 +46,8 @@
 -/api/v*/serverless/progress,get
 -/api/v*/vms/progress,get
 
+# CWP-41843
+-/api/v*/policies/cloud-platforms,get
+
 # Remove route serving GeoIP DB GH #40773
 -/api/v*/util/dbip-country-lite.mmdb,get


### PR DESCRIPTION
Added and updated VM image scan files based on the issue:
https://redlock.atlassian.net/browse/CWP-36091

@iansk : I have not added the VM image scan progress endpoint. Can you please confirm if I need to add the 'progress' endpoint for VM Image scan?

We had earlier decided to remove all the progress endpoints here: https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/339 (based on https://redlock.atlassian.net/browse/PCSUP-7114)