### PR TITLE
Update disaster_recovery.adoc

### DIFF
--- a/compute/admin_guide/configure/disaster_recovery.adoc
+++ b/compute/admin_guide/configure/disaster_recovery.adoc
@@ -105,7 +105,7 @@ As long as the specified backup directory (by default, _/var/lib/twistlock-backu
 
 . Click *Restore* on one of the system or manual backups.
 
-. After the database is reloaded from the backup file, restart Console.
+. After the database is reloaded from the backup file, refresh Console.
 +
 For a onebox installation, ssh to the host where Console runs, then run the following command:
 +


### PR DESCRIPTION
For SaaS version, Changed Restart console to Refresh Console, as Customer will not have underlying server access (for SaaS version).

