### PR TITLE
Removed note for requiring admin privileges to scan the registry

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/scan_artifactory.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/scan_artifactory.adoc
@@ -43,8 +43,6 @@ image::jfrogArtifactory-ca.png[width=350]
 .. In *Version*, select one of:
 *JFrog Artifactory* - Auto-discover and scan all images in all repos across the Artifactory service for versions of Artifactory greater than or equal to 6.2.0.
 +
-NOTE: If you have selected the “JFrog Artificatory” version, then Prisma Cloud requires an account with Administrator privileges (admin user). This is because some of the Artifactory APIs that Prisma Cloud uses to perform discovery require Administrator privileges.
-+
 image::scan_artifactory_subdomain_all.png[width=50]
 +
 *Docker Registry v2* - Scan all images in all repos under a specific repository key for the subdomain method. Repository keys effectively subdivide the Artifactory service into stand-alone fully-compliant Docker v2 registries.


### PR DESCRIPTION
Removed note for requiring admin privileges to scan the registry - After QA checked this, we do not need an admin user in order to scan the registry.
https://redlock.atlassian.net/browse/CWP-42757