### PR TITLE
Correct Base Images Path

### DIFF
--- a/compute/rn/release-information/release-notes-22-12.adoc
+++ b/compute/rn/release-information/release-notes-22-12.adoc
@@ -183,7 +183,7 @@ image::vulnerability-blocked-severitiy-risk-factor.png[scale=20]
 ==== Exceptions for Base Image Vulnerabilities
 
 For deployed and CI images, you can now https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition-admin/vulnerability_management/base_images[exclude base image vulnerabilities] introduced by the base images or the middleware image while configuring the Vulnerability Management rules under *Defend > Vulnerabilities > Images > Deployed/CI*. 
-To use this feature, you need to first specify the base image under *Monitor > Vulnerabilities > Images > Base images*.
+To use this feature, you need to first specify the base image under *Defend > Vulnerabilities > Images > Base images*.
 
 image::exclude-base-image-vulnerabilities.png[scale=20]
 


### PR DESCRIPTION
In the 'Exceptions for Base Image Vulnerabilities' section, the path should be should be Defend > Vulnerabilities > Images > Base images instead of Monitor > Vulnerabilities > Images > Base images.

