### PR TITLE
Update certificates.adoc

### DIFF
--- a/compute/admin_guide/configure/certificates.adoc
+++ b/compute/admin_guide/configure/certificates.adoc
@@ -68,7 +68,7 @@ endif::[]
 |Admission webhook authentication with Prisma Cloud Defender
 |No
 |Defender CA (defender-ca.pem)
-|No
+|Yes
 |Compute edition, Enterprise edition
 
 |===


### PR DESCRIPTION
To my knowledge when  a custom CA is uploaded to the console it will be used to create admission cert/key pair.    Is this not the case?

