### PR TITLE
Removed reference to data exfil case in DNS logs onboarding page

### DIFF
--- a/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-your-aws-account/enable-dns-logs-ingestion.adoc
+++ b/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-your-aws-account/enable-dns-logs-ingestion.adoc
@@ -3,7 +3,7 @@
 
 == Configure DNS Logs Ingestion from Amazon
 
-Prisma Cloud ingests the DNS logs from Amazon Kinesis Data Firehose and leverages those DNS query logs for DNS threat detection use cases, such as data exfiltration, DGAs, and cryptomining. Prisma Cloud fetches the DNS query logs for an account that is streamed in Amazon Kinesis Data Firehose Stream in a logging account on AWS. 
+Prisma Cloud ingests the DNS logs from Amazon Kinesis Data Firehose and leverages those DNS query logs for DNS threat detection use cases, such as randomly generated domains (DGAs) and cryptomining. Prisma Cloud fetches the DNS query logs for an account that is streamed in Amazon Kinesis Data Firehose Stream in a logging account on AWS. 
 
 [NOTE]
 ====


### PR DESCRIPTION
The data exfil threat case is not covered with DNS logs.

