### PR TITLE
PCSUP-13302: Update note for unsupported query parameters

### DIFF
--- a/api/descriptions/hosts/download_get.md
+++ b/api/descriptions/hosts/download_get.md
@@ -2,7 +2,7 @@ Downloads all host scan reports in CSV format.
 
 This endpoint maps to the CSV hyperlink in **Monitor > Vulnerabilities > Hosts > Running hosts** in the Console UI.
 
-**Note**: The query parameter `fields` is not supported for this API endpoint.
+**Note**: The query parameter `fields`, `complianceID` and `normalizedSeverity` are not supported for this API endpoint.
 
 ### cURL Request
 

--- a/api/descriptions/hosts/download_get.md
+++ b/api/descriptions/hosts/download_get.md
@@ -2,7 +2,7 @@ Downloads all host scan reports in CSV format.
 
 This endpoint maps to the CSV hyperlink in **Monitor > Vulnerabilities > Hosts > Running hosts** in the Console UI.
 
-**Note**: The query parameter `fields`, `complianceID` and `normalizedSeverity` are not supported for this API endpoint.
+**Note**: The query parameters `fields`, `complianceID` and `normalizedSeverity` are not supported for this API endpoint.
 
 ### cURL Request
 


### PR DESCRIPTION
@Pubs-MV and @iansk: Updated the note that lists the unsupported query parameters. The rest is engineering task to remove the unsupported query parameters from the OpenAPI spec file. We can then republish.

This is ready for merge based on the discussions in PCSUP-13302 about unsupported query parameters.