### PR TITLE
Adds a screenshot to clarify the context for WAAS deployment on Windows Host

### DIFF
--- a/compute/admin_guide/waas/deploy_waas/deployment_hosts.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deployment_hosts.adoc
@@ -77,10 +77,11 @@ NOTE: If your application uses *TLS* or *gRPC*, you must specify a port number.
 
 .. Enter *WAAS Port (only required for Windows or when using xref:../waas_advanced_settings.adoc#remote-host["Remote host"] option)*.
 +
+image::waas_endpoint_lineitem_app_embbded.png[width=550]
 Specify the TCP port on which WAAS listens. WAAS receives traffic from your end-users on this port, processes it, and then sends it to your app on the App port.
 +
 NOTE: Protecting Linux-based hosts does not require specifying a *`WAAS port`* since WAAS listens on the same port as the protected application.
-Because of Windows internal traffic routing mechanisms WAAS and the protected application cannot use the same *`App port`*. Consequently, when protecting Windows-based hosts the *`WAAS port`* should be set to the port end-users send requests to, and the *`App port`* should be set to a *different* port on which the protected application would listen on and WAAS would forward traffic to.  
+Because Windows has its own internal traffic routing mechanisms, WAAS and the protected application cannot use the same *`App port`*. Consequently, when protecting Windows-based hosts the *`WAAS port`* should be set to the port end-users send requests to, and the *`App port`* should be set to a *different* port on which the protected application will listen and to which WAAS will forward traffic.
 
 .. Enter *HTTP host* (optional, wildcards supported).
 +


### PR DESCRIPTION
…when the screen shot (Linux-only) did not match the screen shot in the documentation. For windows, the configuration as identical to App Embedded so added the reference to that screenshot.

TLDR; Added the screenshot with App ports + WAAS Port for WAAS on Windows Host

