### PR TITLE
[Compute AG] Remove links to the Twistlock CDN

### DIFF
--- a/compute/admin_guide/audit/event_viewer.adoc
+++ b/compute/admin_guide/audit/event_viewer.adoc
@@ -1,7 +1,7 @@
 == Event viewer
 
 Prisma Cloud creates and stores audit event records (audits) for all major subsystems.
-Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://cdn.twistlock.com/docs/api/twistlock_api.html[Prisma Cloud API].
+Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://prisma.pan.dev/api/cloud/cwpp/[Prisma Cloud Compute API].
 If you have a centralized syslog collector, you can xref:../audit/logging.adoc[integrate Prisma Cloud] with your existing infrastructure by configuring Prisma Cloud to send all audit events to syslog in https://tools.ietf.org/html/rfc5424[RFC5424]-compliant format.
 
 You can review some of the limits on storing xref:../deployment_patterns/caps.adoc[audit events].

--- a/compute/admin_guide/audit/event_viewer.adoc
+++ b/compute/admin_guide/audit/event_viewer.adoc
@@ -1,7 +1,7 @@
 == Event viewer
 
 Prisma Cloud creates and stores audit event records (audits) for all major subsystems.
-Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://prisma.pan.dev/api/cloud/cwpp/[Prisma Cloud Compute API].
+Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://prisma.pan.dev/api/cloud/cwpp/audits/[Prisma Cloud Compute API].
 If you have a centralized syslog collector, you can xref:../audit/logging.adoc[integrate Prisma Cloud] with your existing infrastructure by configuring Prisma Cloud to send all audit events to syslog in https://tools.ietf.org/html/rfc5424[RFC5424]-compliant format.
 
 You can review some of the limits on storing xref:../deployment_patterns/caps.adoc[audit events].

--- a/compute/admin_guide/continuous_integration/jenkins_plugin.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_plugin.adoc
@@ -137,9 +137,9 @@ Full scan reports for the latest build can be retrieved from:
 * The scan results file in the project's workspace (by the name configured in the scan steps).
 
 * The Prisma Cloud API.
-For more information, see the https://cdn.twistlock.com/docs/api/twistlock_api.html#scans_get[`/api/v1/scans`] endpoint for downloading Jenkins scan results.
+For more information, see the https://prisma.pan.dev/api/cloud/cwpp/scans[`/api/v<VERSION>/scans`] endpoint for downloading Jenkins scan results.
 
-For example, if you use [ThreadFix](https://threadfix.it/) to maintain a consolidated view of vulnerabilities across all your organization’s applications, you could create a post-build action which triggers ThreadFix’s Jenkins plugin to grab Prisma Cloud Compute’s scan report from the project workspace and upload it to the ThreadFix server.
+For example, if you use https://threadfix.it/[ThreadFix] to maintain a consolidated view of vulnerabilities across all your organization’s applications, you could create a post-build action which triggers ThreadFix’s Jenkins plugin to grab Prisma Cloud Compute’s scan report from the project workspace and upload it to the ThreadFix server.
 Contact your ThreadFix support team for details on how to ingest this output.
 
 To download the scan report from Console using the Prisma Cloud API, use the following command:

--- a/compute/admin_guide/vulnerability_management/google_cloud_container_builder.adoc
+++ b/compute/admin_guide/vulnerability_management/google_cloud_container_builder.adoc
@@ -1,4 +1,0 @@
-== Google Cloud Container Builder
-// Not included in the book as of Nov 9,2021
-
-As a prerequisite for performing vulnerability scanning with Google Cloud Container Builder as explained https://www.twistlock.com/2017/03/09/google-cloud-container-builder/[here], download _scan_helper.c_ from https://cdn.twistlock.com/d3951dae/scan_helper.sh[here].


### PR DESCRIPTION
Fix links to the Compute API. Links to downloads/attachments remain as-is.

