### PR TITLE
Removed duplicate addressed issue

### DIFF
--- a/compute/rn/release-information/release-notes-22-12.adoc
+++ b/compute/rn/release-information/release-notes-22-12.adoc
@@ -662,8 +662,6 @@ image::38112-fix-status-version.png[scale=10]
 +
 A new  "Compliance ID" column is added to indicate the compliance-related issues specifically.
 
-* Control for behavior of ambiguous state when using 'vendor fixes are available' condition
-
 //[GH#30643]
 * Python package info is updated to include the path.
 


### PR DESCRIPTION
The addressed issue appeared twice
The deleted line was the same as the addressed issue that is described as: "For some package types, the process for inferring the fix status for CVEs that didn't have a fix status before is improved..."