### PR TITLE
add scheme: https

### DIFF
--- a/compute/admin_guide/audit/prometheus.adoc
+++ b/compute/admin_guide/audit/prometheus.adoc
@@ -282,6 +282,7 @@ global:
 # Prisma Cloud scrape configuration.
 scrape_configs:
   - job_name: 'twistlock'
+    scheme: https
     static_configs:
     - targets: ['CONSOLE_ADDRESS:8083']
     metrics_path: /api/v1/metrics


### PR DESCRIPTION
Step 2 Prometheus.yml file does not work unless "scheme: https" is not added in the Prisma Cloud scrape configuration.

