### PR TITLE
Update deprecated Jenkins Helm chart url

### DIFF
--- a/compute/admin_guide/continuous_integration/jenkins_pipeline_k8s.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_pipeline_k8s.adoc
@@ -68,7 +68,7 @@ stage('Prisma Cloud Scan') {
 You can install Prisma Cloud inside or outside of the cluster, as long as any cluster node can reach Console over the network.
 
 * You have installed Jenkins in your cluster.
-The https://github.com/kubernetes/charts/tree/master/stable/jenkins[Jenkins Helm chart] is the easiest path for bringing up Jenkins in a Kubernetes cluster.
+The https://github.com/jenkinsci/helm-charts[Jenkins Helm chart] is the easiest path for bringing up Jenkins in a Kubernetes cluster.
 
 * xref:../continuous_integration/jenkins_plugin.adoc[Install the Prisma Cloud Jenkins plugin.]
 


### PR DESCRIPTION
replace the deprecated Jenkins Helm chart url https://github.com/helm/charts/tree/master/stable/jenkins with https://github.com/jenkinsci/helm-charts

