### PR TITLE
Update agentless-scanning.adoc

### DIFF
--- a/compute/admin_guide/agentless-scanning/agentless-scanning.adoc
+++ b/compute/admin_guide/agentless-scanning/agentless-scanning.adoc
@@ -3,7 +3,6 @@
 Agentless scanning lets you inspect the risks and vulnerabilities of a cloud workloads without having to install an agent or affecting the execution of your workload.
 Prisma Cloud gives you the flexibility to choose between agentless and agent-based security using Defenders.
 Prisma Cloud supports agentless scanning cloud workloads on AWS, Azure, GCP, and OCI for vulnerabilities and compliance.
-In AWS, Azure, and GCP you can also use agentless scanning for container images.
 
 Continue reading this page to learn about the agentless scanning modes, architecture, and results.
 
@@ -16,17 +15,8 @@ There are two ways you can set up agentless scanning with Prisma Cloud.
 * Scan all hosts of a cloud account within the same cloud account, or
 * Scan all hosts of a cloud account, called _target account_, from another dedicated cloud account, called _hub account_. 
 
-[NOTE]
-====
-Agentless scanning isn't supported for xref:../install/system_requirements.adoc[hosts running Windows].
-Agentless scanning doesn't support Azure hosts with an unmanaged operating system disk.
-Azure hosts with unmanaged operating system disks are skipped during the scan.
-====
-
 [#scanning-modes]
 === Agentless Scanning Modes
-
-In AWS and GCP, the following modes are available for agentless scanning in Prisma Cloud.
 
 ==== Same Account Mode
 


### PR DESCRIPTION
1. Let's avoid mentioning specific limited capabilities on the front page and leave it to a per CSP guidance.
2. Let's not list random limitations on the opening landing page of the feature, let's leave these limitations for SAs to handle, we have many more limitations that we don't list here, so I don't find it helpful to list just 3 random ones.
2. Hub account is only for AWS and GCP, in current structure it implies that we only support AWS and GCP generally - let's drop this altogether

