### PR TITLE
update configure_registry_scanning.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/configure_registry_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/configure_registry_scanning.adoc
@@ -17,7 +17,7 @@ By default, scans occur once every 24 hours, but you can configure periodic scan
 
 To scan images in a registry, create a new registry scan rule.
 
-*Prerequisites:* You have xref:../../install/defender_types.adoc[deployed at least one Defender in your environment].
+*Prerequisites:* You have xref:../../install/defender_types.adoc[deployed at least one Container Defender in your environment].
 
 [.procedure]
 . On the Prisma Cloud Console, go to *Defend > Vulnerabilities > Images > Registry settings*.


### PR DESCRIPTION
pre-requisites should correctly refer to container defender to match "deployment patterns" later in the document as this is valid

