### PR TITLE
[Compute AG] Fix required GCR Scan IAM role -CWP-45521

### DIFF
--- a/compute/admin_guide/vulnerability_management/registry_scanning/scan_gcr.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/scan_gcr.adoc
@@ -9,7 +9,7 @@
 
 // Stroage view role discussion from https://panw-global.slack.com/archives/CL11MD99Q/p1572381568427500
 * GCR access is governed by Google's storage permissions.
-For Prisma Cloud to scan GCR, your service account must have the GCP IAM *Storage View* role.
+For Prisma Cloud to scan GCR, your service account must have the GCP IAM *Storage Object Viewer* role (see https://cloud.google.com/container-registry/docs/access-control#permissions_and_roles).
 
 * You must grant Prisma Cloud access to your registry with a https://cloud.google.com/container-registry/docs/advanced-authentication[service account JSON key file].
 Your JSON token blob will look something like this:


### PR DESCRIPTION
The required IAM role is called `Storage Object Viewer`.

