### PR TITLE
clarify user_roles.adoc

### DIFF
--- a/compute/admin_guide/authentication/user_roles.adoc
+++ b/compute/admin_guide/authentication/user_roles.adoc
@@ -213,7 +213,7 @@ When creating a role, you will be able to select which sections of the product t
 The permissions you grant for a role will apply to both the Prisma Cloud UI and API.
 
 Read permission will grant the role with access to all GET APIs for fetching data.
-Write permission will grant the role with access to all other APIs (POST, PUT, DELETE, etc.) for saving data and performing actions, in addition to all GET APIs.
+Write permission will grant the role with access to all other APIs (POST, PUT, DELETE, etc.) for saving data and performing actions, in addition to all GET APIs. 
 
 IMPORTANT: If a role allows access to policies, users with this role will be able to see all rules and all collections that scope rules under the Defend section, even if the user's view of the environment is restricted by assigned collections.
 


### PR DESCRIPTION
this shows up in the saas docs, but none of these roles are relevant to SaaS in any way. None of them are available. We need to clarify that piece and/or remove this page entirely as it has no value technically for SaaS deployments. Perhaps PM team or platform team can comment or something

