### PR TITLE
Update book metadata for "Edit on GitHub" links

### DIFF
--- a/code-security/admin_guide/book.yml
+++ b/code-security/admin_guide/book.yml
@@ -29,10 +29,11 @@ author: Prisma Cloud Team
 ditamap: code-security-admin
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-admin-code-security
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-admin-code-security
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: code-security/admin_guide
+  branch: master
 ---
 kind: chapter
 name: Get Started with Prisma Cloud Code Security

--- a/compute/admin_guide/book_compute_edition.yml
+++ b/compute/admin_guide/book_compute_edition.yml
@@ -8,10 +8,11 @@ dita: techdocs/en_US/dita/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition
 graphics: techdocs/en_US/dita/_graphics/22-12/prisma-cloud-compute-edition-admin
 attributes:
   compute_edition: true
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/admin_guide
+  branch: master
 ---
 kind: chapter
 name: Welcome

--- a/compute/admin_guide/book_prisma_cloud.yml
+++ b/compute/admin_guide/book_prisma_cloud.yml
@@ -8,10 +8,11 @@ dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-admin-compute
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-compute-admin
 attributes:
   prisma_cloud: true
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/admin_guide
+  branch: master
 ---
 kind: chapter
 name: Welcome

--- a/compute/is_notifications/book.yml
+++ b/compute/is_notifications/book.yml
@@ -6,10 +6,11 @@ version: " "
 ditamap: prisma-cloud-intelligence-stream-notifications
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-intelligence-stream
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-intelligence-stream
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/is_notifications
+  branch: master
 ---
 kind: chapter
 name: Prisma(TM) Cloud Intelligence Stream Significant Changes

--- a/compute/ops_guide/book.yml
+++ b/compute/ops_guide/book.yml
@@ -5,10 +5,11 @@ author: Prisma Cloud team
 ditamap: prisma-cloud-operationalize-compute
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-operationalize-compute/
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-compute-operationalize
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/ops_guide
+  branch: master
 ---
 kind: chapter
 name: Getting started

--- a/compute/public_sector/book.yml
+++ b/compute/public_sector/book.yml
@@ -5,10 +5,11 @@ version: 0.0
 author: Prisma Cloud team
 ditamap: prisma-cloud-compute-edition-public-sector
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-compute-edition-public-sector
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/public_sector
+  branch: master
 ---
 kind: chapter
 name: DISA STIG

--- a/compute/ref_arch/book.yml
+++ b/compute/ref_arch/book.yml
@@ -5,10 +5,11 @@ author: Prisma Cloud team
 ditamap: prisma-cloud-reference-architecture-compute
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-reference-architecture-compute
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-compute-reference-architecture
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/ref_arch
+  branch: master
 ---
 kind: chapter
 name: Objectives

--- a/compute/rn/book.yml
+++ b/compute/rn/book.yml
@@ -6,10 +6,11 @@ version: "22.12"
 ditamap: prisma-cloud-compute-edition-release-notes
 dita: techdocs/en_US/dita/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition-release-notes
 graphics: techdocs/en_US/dita/_graphics/22-12/prisma-cloud-compute-edition-release-notes
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: compute/rn
+  branch: master
 ---
 kind: chapter
 name: Prisma(TM) Cloud Compute Edition Release Information

--- a/cspm/admin-guide/book.yml
+++ b/cspm/admin-guide/book.yml
@@ -5,10 +5,11 @@ author: Prisma Cloud Tech Docs
 ditamap: prisma-cloud-admin
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-admin
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-admin
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: cspm/admin-guide
+  branch: master
 ---
 kind: chapter
 name: Get Started with Prisma Cloud

--- a/cspm/rn/book.yml
+++ b/cspm/rn/book.yml
@@ -5,10 +5,11 @@ author: Prisma Cloud Tech Docs
 ditamap: prisma-cloud-release-notes
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-release-notes
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-release-notes
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: cspm/rn
+  branch: master
 ---
 kind: chapter
 name: Prisma™ Cloud Release Information

--- a/cspm/rql-reference/book.yml
+++ b/cspm/rql-reference/book.yml
@@ -5,10 +5,11 @@ author: Prisma Cloud Tech Docs
 ditamap: prisma-cloud-rql-reference
 dita: techdocs/en_US/dita/prisma/prisma-cloud/prisma-cloud-rql-reference
 graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/rql-reference
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: cspm/rql-reference
+  branch: master
 ---
 kind: chapter
 name: Prisma Cloud RQL Reference

--- a/template/book.yml
+++ b/template/book.yml
@@ -29,10 +29,11 @@ author: Arthur Read
 ditamap: template
 dita: techdocs/en_US/dita/test/github-test/template
 graphics: techdocs/en_US/dita/test/github-test/template/_graphics
-repo:
-  url: https://github.com/PaloAltoNetworks/prisma-cloud-docs
-  branch: master
+github:
+  owner: PaloAltoNetworks
+  repo: prisma-cloud-docs
   bookdir: template
+  branch: master
 ---
 kind: chapter
 name: Welcome


### PR DESCRIPTION
The latest version of panconv (23.02.10) requires slightly different metadata when generating the "Edit on GitHub" links. Update the book metadata to align with panconv's requirements.