### PR TITLE
Note for Backward Compatibility list

### DIFF
--- a/compute/rn/release-information/release-notes-22-12.adoc
+++ b/compute/rn/release-information/release-notes-22-12.adoc
@@ -667,6 +667,7 @@ A new  "Compliance ID" column is added to indicate the compliance-related issues
 
 
 === Backward Compatibility for New Features
+NOTE: For Prisma Cloud Enterprise (SaaS) tenants, any defenders that are older than 22.01 will no longer be able to connect to the console. 
 
 [options="header"]
 |===


### PR DESCRIPTION
Clearly state that N-2 compatibility window is a hard requirement for SaaS tenants. This should be stated moving forward. The version number should be updated with new major releases (23.06, N-2 would be 22.06, 23.12, N-2 would be 22.12, etc)

