### PR TITLE
[CodeSec RN] Remove Custom Secrets

### DIFF
--- a/cspm/rn/prisma-cloud-code-security-release-information/features-introduced-in-code-security-2023/features-introduced-in-code-security-february-2023.adoc
+++ b/cspm/rn/prisma-cloud-code-security-release-information/features-introduced-in-code-security-2023/features-introduced-in-code-security-february-2023.adoc
@@ -39,12 +39,4 @@ After configuring a Transporter in your environment, followed by authentication 
 
 image::codesec-rn-feb-23-transporter.png[scale=30]
 
-
-|*Code Editor for Custom Secrets*
-
-| In addition to the custom policy for build-time checks, Code Editor now helps you define a regular expression patterns for Custom Secrets identified on the Prisma Cloud console. The policy violation for custom secrets will continue to be viewable on *Code Security > Projects*.
-
-
-image::codesec-rn-feb-23-custom-secrets.png[scale=30]
-
 |===


### PR DESCRIPTION
Removed Custom Secrets from RN as per Taylor's request. 
Change applicable for PCS 23.2.2 release.

Summary of Changes:

Modified files:
- features-introduced-in-code-security-february-2023.adoc
