### PR TITLE
[Compute AG]: Update Prisma.pan.dev references to Pan.dev

### DIFF
--- a/compute/admin_guide/api/api.adoc
+++ b/compute/admin_guide/api/api.adoc
@@ -1,11 +1,11 @@
 == API
 
-All information for the CWPP API has now moved to https://prisma.pan.dev[prisma.pan.dev], our home for developer docs.
+All information for the CWPP API has now moved to https://pan.dev[pan.dev], our home for developer docs.
 
 *API reference:*
 
-https://prisma.pan.dev/api/cloud/cwpp
+https://pan.dev/compute/api/
 
 *API-related documentation, including the porting guide:*
 
-https://prisma.pan.dev/docs/cloud/cwpp/cwpp-gs
+https://pan.dev/docs/prisma-cloud/docs/

--- a/compute/admin_guide/audit/audit_admin_activity.adoc
+++ b/compute/admin_guide/audit/audit_admin_activity.adoc
@@ -23,6 +23,6 @@ The following screenshot shows the changes to a vulnerability management rule:
 
 image::admin_activity_audit_trail_diff.png[width=600]
 
-Use the https://prisma.pan.dev/api/cloud/cwpp/policies/[API reference] to view information on the API endpoint.
+Use the https://pan.dev/compute/api/get-policies-vulnerability-ci-images/[API reference] to view information on the API endpoint.
 The `/api/22.01/policies/vulnerability/ci/images` endpoint creates and modifies vulnerability rules for images scanned in the CI process.
 In this case, user `name obscured` has changed the threshold for the grace period for fixing Critical and High severity CVEs to 2 days and 4 days respectively after the vulnerability was published or disclosed.

--- a/compute/admin_guide/audit/delete_audit_logs.adoc
+++ b/compute/admin_guide/audit/delete_audit_logs.adoc
@@ -61,4 +61,4 @@ Deletes an access event with specific id.
   {}
 
 NOTE: The current set up enables user to delete entries at the access layer for each runtime sensor.
-To learn more on API calls, see the https://prisma.pan.dev/api/cloud/cwpp[API reference].
+To learn more on API calls, see the https://pan.dev/compute/api/[API reference].

--- a/compute/admin_guide/audit/event_viewer.adoc
+++ b/compute/admin_guide/audit/event_viewer.adoc
@@ -1,7 +1,7 @@
 == Event viewer
 
 Prisma Cloud creates and stores audit event records (audits) for all major subsystems.
-Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://prisma.pan.dev/api/cloud/cwpp/audits/[Prisma Cloud Compute API].
+Audits can be reviewed in *Monitor > Events*, or they can be retrieved from the https://pan.dev/compute/api/get-audits-access/[Prisma Cloud Compute API].
 If you have a centralized syslog collector, you can xref:../audit/logging.adoc[integrate Prisma Cloud] with your existing infrastructure by configuring Prisma Cloud to send all audit events to syslog in https://tools.ietf.org/html/rfc5424[RFC5424]-compliant format.
 
 You can review some of the limits on storing xref:../deployment_patterns/caps.adoc[audit events].

--- a/compute/admin_guide/authentication/oidc.adoc
+++ b/compute/admin_guide/authentication/oidc.adoc
@@ -11,7 +11,7 @@ This page includes instructions to integrate with the following providers:
 * <<azure-ad,Azure Active Directory>>
 
 Use the *\https://<CONSOLE>:<PORT>/api/v1/authenticate/callback/oidc* URL only to configure the integration between services.
-The API is not included in https://prisma.pan.dev/api/cloud/cwpp/[our reference guide] because the URL is only enabled as a configuration value.
+The API is not included in https://pan.dev/compute/api/[our reference guide] because the URL is only enabled as a configuration value.
 
 [#pingone]
 === PingOne

--- a/compute/admin_guide/configure/logon_settings.adoc
+++ b/compute/admin_guide/configure/logon_settings.adoc
@@ -81,7 +81,7 @@ Twistlock lets you disable basic authentication to the Console and API.  Basic a
 
 With _twistcli_, you need to use the '_--token_' option to authenticate with the Console for image scanning and other operations that access Console.
 This is the same token you receive form the /api/v1/authenticate API endpoint.
-For more inforomation, see the https://prisma.pan.dev[API documentation].
+For more inforomation, see the https://pan.dev/compute/api/[API documentation].
 
 With the API, you would have use the authenticate endpoint to generate an authentication token to access any of the endpoints.  Accessing the APi with Basic Authentication would not be allowed.
 

--- a/compute/admin_guide/continuous_integration/jenkins_plugin.adoc
+++ b/compute/admin_guide/continuous_integration/jenkins_plugin.adoc
@@ -123,7 +123,7 @@ Full scan reports for the latest build can be retrieved from:
 * The scan results file in the project's workspace (by the name configured in the scan steps).
 
 * The Prisma Cloud API.
-For more information, see the https://prisma.pan.dev/api/cloud/cwpp/scans[`/api/v<VERSION>/scans`] endpoint for downloading Jenkins scan results.
+For more information, see the https://pan.dev/compute/api/get-scans/[`/api/v<VERSION>/scans`] endpoint for downloading Jenkins scan results.
 
 For example, if you use https://threadfix.it/[ThreadFix] to maintain a consolidated view of vulnerabilities across all your organization's applications, you could create a post-build action that triggers ThreadFix's Jenkins plugin to grab Prisma Cloud Compute's scan report from the project workspace and upload it to the ThreadFix server.
 Contact your ThreadFix support team for details on how to ingest this output.

--- a/compute/admin_guide/tools/twistcli_scan_images.adoc
+++ b/compute/admin_guide/tools/twistcli_scan_images.adoc
@@ -364,7 +364,7 @@ The API returns comprehensive information for each scan report, including the fu
 
 The following example `curl` command calls the API with Basic authentication.
 You'll need to apply some filtering with tools like `jq` to extract specific items from the response.
-For more information on accessing the API, see the https://prisma.pan.dev[API reference].
+For more information on accessing the API, see the https://pan.dev/compute/api/[API reference].
 
 ----
 $ curl \
@@ -537,7 +537,7 @@ image::detailed_scan.png[width=750]
 
 . This outputs a tabular representation of your scan results to stdout.
 If you need to retrieve the results of your scan in JSON format, this can be done using the API.
-For more information on the API, see the https://prisma.pan.dev[API reference].
+For more information on the API, see the https://pan.dev/compute/api/[API reference].
 
 .. Call the API with authentication (demonstrated here using Basic authentication) to fetch the results of the scan.
 +

--- a/compute/admin_guide/vulnerability_management/registry_scanning/configure_registry_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/registry_scanning/configure_registry_scanning.adoc
@@ -56,7 +56,7 @@ The *Last scan time* of a registry is updated under *Registry details > General 
 
 ==== On-demand Registry Scanning
 
-You can trigger an on-demand scan for individual images with the https://prisma.pan.dev/api/cloud/cwpp/registry#operation/post-registry-scan[Scan Registry API]. This feature allows you to scan the images immediately and not wait for the next periodic scan. You can trigger multiple on-demand image scans without interrupting the main registry scanning process. 
+You can trigger an on-demand scan for individual images with the https://pan.dev/compute/api/post-registry-scan/[Scan Registry API]. This feature allows you to scan the images immediately and not wait for the next periodic scan. You can trigger multiple on-demand image scans without interrupting the main registry scanning process. 
 However, every trigger is for a single image only.
 
 NOTE: For the on-demand scan, you must pre-define the image registry scope in the xref:registry_scanning.adoc[registry scanning configuration].

--- a/compute/admin_guide/vulnerability_management/risk_tree.adoc
+++ b/compute/admin_guide/vulnerability_management/risk_tree.adoc
@@ -24,4 +24,4 @@ The API returns an ordered tree of the images that contain those vulnerabilities
 This allows you to automate, with a single API call, the creation of a detailed map of your exposure to the vulnerabilities.
 
 For complete details about the response object, see the 
-https://prisma.pan.dev/api/cloud/cwpp/stats#operation/get-stats-vulnerabilities-impacted-resources[API reference] image:ext-link-icon-small.png[scale=100]
+https://pan.dev/compute/api/get-stats-vulnerabilities-impacted-resources/[API reference] image:ext-link-icon-small.png[scale=100]

--- a/compute/admin_guide/welcome/support_lifecycle.adoc
+++ b/compute/admin_guide/welcome/support_lifecycle.adoc
@@ -34,8 +34,8 @@ Prisma Cloud has an 'n-2' support policy which means the current release ('n') a
 Note that in some cases, the resolution of a problem in the n-1 or n-2 version may require upgrading to a current build.
 Prisma Cloud will make commercially reasonable efforts to work with customers that require porting fixes back to the n-1 or n-2 versions, but sometimes architectural changes are significant enough between versions that this is practically impossible without making the n-1 or n-2 versions essentially the same as the n version.
 
-There will be version-specific https://prisma.pan.dev/docs/cloud/cwpp/stable-endpoints[API endpoints]. With API versioning, as your Console is upgraded to newer versions, you can continue to use older versioned APIs with stability and migrate to newer version APIs at your convenience within the n-2 support lifecycle. 
-As a best practice, update your scripts to use the version-specific API endpoints to ensure that your implementation is fully supported. For the version-specific APIs, you will have access to the https://prisma.pan.dev/api/cloud/cwpp[API Reference] and Release Notes documentation for changes or updates that may impact you.
+There will be version-specific https://pan.dev/compute/api/stable-endpoints/[API endpoints]. With API versioning, as your Console is upgraded to newer versions, you can continue to use older versioned APIs with stability and migrate to newer version APIs at your convenience within the n-2 support lifecycle. 
+As a best practice, update your scripts to use the version-specific API endpoints to ensure that your implementation is fully supported. For the version-specific APIs, you will have access to the https://pan.dev/compute/api/[API Reference] and Release Notes documentation for changes or updates that may impact you.
 
 
 === Third-party software

--- a/compute/admin_guide/welcome/upcoming_support_lifecycle_changes.adoc
+++ b/compute/admin_guide/welcome/upcoming_support_lifecycle_changes.adoc
@@ -22,7 +22,7 @@ We’re announcing the following changes, effective in Prisma Cloud Compute "Ive
 
 === Versioned API with guaranteed reliable endpoint behaviors
 
-* Currently, the Compute API is not versioned between releases, though there are a set of APIs which very rarely change documented in our https://prisma.pan.dev/docs/cloud/cwpp/stable-endpoints[API stability guide].
+* Currently, the Compute API is not versioned between releases, though there are a set of APIs which very rarely change documented in our https://pan.dev/compute/api/stable-endpoints/[API stability guide].
 * Beginning in Iverson, each release of Console will include versioned API endpoints for the prior supported releases, with a guarantee that the included endpoint behaviors will remain constant for a given version.
 * Only APIs covered in the Stability Guide are included in these versioned endpoints; access to other APIs will not be actively prevented but they will be unsupported, undocumented, and may change at any time.
 * This will be phased in, beginning with the Iverson release, which will include a `/v-Iverson` endpoint as well as the existing `/v1` endpoint.


### PR DESCRIPTION
Urls adjusted for the new pan.dev API reference site.

To be merged when the pan.dev turns live.