### PR TITLE
Add section on GKE Autopilot docs

### DIFF
--- a/compute/admin_guide/install/install-gke-autopilot.adoc
+++ b/compute/admin_guide/install/install-gke-autopilot.adoc
@@ -20,6 +20,7 @@ GKE Autopilot clusters are using https://cloud.google.com/kubernetes-engine/docs
 The `--gke autopilot flag adds the 'autopilot.gke.io/no-connect: "true"`' annotation to the YAML file and `--cri` flag enables the CRI option for nodes that use the Container Runtime Interface (CRI), not Docker. It also removes the  '/var/lib/containers' mount from the generated file as that configuration is not required for the GKE autopilot deployment.
 +
 NOTE: If you are using the web interface, on  *Manage > Defenders > Deploy > Defenders* ensure that the *orchestrator type* is *Kubernetes*, and that the *Nodes use Container Runtime Interface (CRI), not Docker* and *GKE Autopilot deployment* are set to be *On*.
+NOTE: GKE AUTOPILOT DEFENDERS WILL ONLY WORK WITH OFFICIAL TWISTLOCK REGISTRY, NOT CUSTOMER PROVIDED REGISTRY
 
 . Create the *twistlock* namespace on your cluster by running the following command:
      


### PR DESCRIPTION
Add section on GKE Autopilot docs that explicity states "GKE AUTOPILOT DEFENDERS WILL ONLY WORK WITH OFFICIAL TWISTLOCK REGISTRY, NOT CUSTOMER PROVIDED REGISTRY" in regards to the defender image. This is causing a lot of issues with my customers and should be stated in the documentation. I didn't know this until I dug through a bunch of PCSUPs.

