### PR TITLE
PanDev script to sort tags in OpenAPI spec

### DIFF
--- a/api/_build/src/sort_tags.py
+++ b/api/_build/src/sort_tags.py
@@ -1,0 +1,16 @@
+import json
+
+input_file = input("Enter the path and name of the input JSON file: ")
+output_file = input("Enter the path and name of the output JSON file: ")
+
+with open(input_file, 'r') as json_file:
+    json_data = json.load(json_file)
+    for tag in json_data['tags']:
+        json_data['tags'].sort(key=lambda x: x['name'])
+    for path, methods in json_data["paths"].items():
+        for method in ["put", "get", "delete", "post", "patch"]:
+            if method in methods and "Supported API" in methods[method].get("tags", []):
+                methods[method]["tags"].remove("Supported API")
+
+with open(output_file, 'w') as json_file:
+    json.dump(json_data, json_file, indent=4)


### PR DESCRIPTION
This python script removes the unwanted "Supported API" tag from the endpoints and sorts the tags alphabetically.

In pan.dev, a monolithic OpenAPI spec works the best. Instead of generating microspecs after enrichment, you can use this script to finalise your OpenAPI spec for copying to pan.dev.

The updated process for generating specs for pan.dev is mentioned here:
https://docs.google.com/document/d/1Ur0z0xQq8tOCiKhhvNNi1kNqpZ2zDmuB7FWQSULPhj0/edit?usp=sharing

