### PR TITLE
[Compute AG:Usabilla]:Fix anchors in Serverless Defender TOC

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -44,6 +44,7 @@ The following runtimes are supported for Azure Functions (Windows and 64 bit onl
 Only users with the Administrator role can see the list of deployed Serverless Defenders in *Manage > Defenders > Manage*.
 ====
 
+[#secure-serverless-functions]
 === Securing serverless functions
 
 To secure a serverless function, embed the Prisma Cloud Serverless Defender into it.
@@ -61,6 +62,7 @@ The steps are:
 
 
 [.task]
+[#aws-lambda-download-function-zip-file]
 === AWS Lambda - (Optional) Download your function as a ZIP file
 
 Download your function's source code from AWS as a ZIP file.
@@ -78,6 +80,7 @@ In the next step, you'll download the Serverless Defender files to this working 
 
 
 [.task]
+[#aws-lamda-embed-serverless-defender-into-c-function]
 === AWS Lambda - Embed Serverless Defender into C# functions
 
 In your function code, import the Serverless Defender library and create a new protected handler that wraps the original handler.
@@ -165,9 +168,9 @@ Serverless Defender uses TW_POLICY to determine how to connect to Compute Consol
 +
 Copy the value generated for TW_POLICY, and set it aside.
 
-. xref:_upload_the_protected_function_to_aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
+. xref:upload-protected-function-to-aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
 
-[#embed_serverless_defender_into_java_functions]
+[#embed-serverless-defender-into-java-functions]
 [.task]
 === AWS Lambda - Embed Serverless Defender into Java functions
 
@@ -394,10 +397,11 @@ Serverless Defender uses TW_POLICY to determine how to connect to Compute Consol
 +
 Copy the value generated for TW_POLICY, and set it aside.
 
-. xref:_upload_the_protected_function_to_aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
+. xref:upload-protected-function-to-aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
 
 
 [.task]
+[embed-serverless-defender-into-nodejs-functions]
 === AWS Lambda - Embed Serverless Defender into Node.js functions
 
 Import the Serverless Defender module, and configure your function to start it.
@@ -454,11 +458,12 @@ Serverless Defender uses TW_POLICY to determine how to connect to Compute Consol
 +
 Copy the value generated for TW_POLICY, and set it aside.
 
-. xref:_upload_the_protected_function_to_aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
+. xref:upload-protected-function-to-aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
 * Prisma Cloud Serverless Defender includes native node.js libraries. If you are using webpack, please refer to tools such as https://www.npmjs.com/package/native-addon-loader[native-addon-loader] to make sure these libraries are included in the function ZIP file.
 
 
 [.task]
+[#aws-lamda-python-functions]
 === AWS Lambda - Embed Serverless Defender into Python functions
 
 Import the Serverless Defender module, and configure your function to invoke it.
@@ -500,10 +505,11 @@ Serverless Defender uses TW_POLICY to determine how to connect to Compute Consol
 +
 Copy the value generated for TW_POLICY, and set it aside.
 
-. xref:_upload_the_protected_function_to_aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
+. xref:upload-protected-function-to-aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
 
 
 [.task]
+[embed-serverless-defender-into-ruby-functions]
 === AWS Lambda - Embed Serverless Defender into Ruby functions
 
 Import the Serverless Defender module, and configure your function to invoke it.
@@ -573,10 +579,10 @@ Serverless Defender uses TW_POLICY to determine how to connect to Compute Consol
 +
 Copy the value generated for TW_POLICY, and set it aside.
 
-. xref:_upload_the_protected_function_to_aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
+. xref:upload-protected-function-to-aws[Upload the protected function to AWS, and set the TW_POLICY environment variable.]
 
 
-[#_upload_the_protected_function_to_aws]
+[#upload-protected-function-to-aws]
 [.task]
 === AWS Lambda - Upload the protected function
 
@@ -613,6 +619,7 @@ image::install_serverless_defender_upload_zip.png[width=800]
 
 
 [.task]
+[#azure-functions]
 === Azure Functions - Embed Serverless Defender into C# functions
 
 In your function code, import the Serverless Defender library and create a new protected handler that wraps the original handler.
@@ -700,7 +707,7 @@ Copy the value generated for TW_POLICY, and set it aside.
 . Upload the protected function to Azure, and set the TW_POLICY environment variable.
 
 
-[#_defining_policy]
+[#define-policy]
 [.task]
 === Defining your runtime protection policy
 
@@ -750,7 +757,7 @@ For Azure Funtions only, you can additionally scope rules by account ID.
 . Click *Save*.
 
 
-[#_defining_cnaf_policy]
+[#define-cnaf-policy]
 [.task]
 === Defining your serverless WAAS policy
 


### PR DESCRIPTION
Reference: Usabilla ticket feedback on the [Serverless Defender](https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition-admin/install/install_defender/install_serverless_defender) page.

Context: Broken TOC links

Reason: Missing/incorrect anchors
