### PR TITLE
[Compute AG]: Fix anchor links in TOC

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -401,7 +401,7 @@ Copy the value generated for TW_POLICY, and set it aside.
 
 
 [.task]
-[embed-serverless-defender-into-nodejs-functions]
+[#embed-serverless-defender-into-nodejs-functions]
 === AWS Lambda - Embed Serverless Defender into Node.js functions
 
 Import the Serverless Defender module, and configure your function to start it.
@@ -509,7 +509,7 @@ Copy the value generated for TW_POLICY, and set it aside.
 
 
 [.task]
-[embed-serverless-defender-into-ruby-functions]
+[#embed-serverless-defender-into-ruby-functions]
 === AWS Lambda - Embed Serverless Defender into Ruby functions
 
 Import the Serverless Defender module, and configure your function to invoke it.

--- a/compute/admin_guide/install/system_requirements.adoc
+++ b/compute/admin_guide/install/system_requirements.adoc
@@ -336,7 +336,7 @@ When running on a Docker host, Prisma Cloud Defender uses the following files/fo
 * _/var/lib/twistlock_ -- Required for storing Prisma Cloud data.
 * _/dev/log_ -- Required for writing to syslog.
 
-[#docker_support]
+[#docker-support]
 === Docker Engine
 
 Prisma Cloud supports only the versions of the Docker Engine supported by Docker itself. Prisma Cloud supports only the following official mainstream Docker releases and later versions.
@@ -365,6 +365,7 @@ The versions of Docker Engine listed apply to versions you independently install
 The versions shipped as a part of an orchestrator, such as Red Hat OpenShift, might defer.
 Prisma Cloud supports the version of Docker Engine that ships with any Prisma Cloud-supported version of the orchestrator.
 
+[#container-runtimes]
 === Container Runtimes
 
 Prisma Cloud supports the following container runtimes:
@@ -414,7 +415,7 @@ Helm v3.9, v3.10, v3.10.3, and 3.11 are supported.
 Prisma Cloud is supported on the following orchestrators.
 We support the following versions of official mainline vendor/project releases.
 
-[#x86_64-orchestrators]
+[#x86-64-orchestrators]
 ==== Supported Orchestrators on x86_64
 
 [cols="25%,75%a", options="header"]
@@ -638,7 +639,7 @@ Comprehensive Common Vulnerabilities and Exposures (CVE) data is provided for th
 
 If a CVE doesn't have an architecture identifier, the CVE is related to all architectures.
 
-[#serverless_runtimes]
+[#serverless-runtimes]
 === Serverless Runtimes
 
 Prisma Cloud offers multiple features to help you secure your serverless runtimes on AWS, Azure, and GCP.

--- a/compute/admin_guide/upgrade/upgrade_onebox.adoc
+++ b/compute/admin_guide/upgrade/upgrade_onebox.adoc
@@ -45,4 +45,4 @@ To upgrade your `console` install, run:
 +
   $ sudo ./twistlock.sh -syj console
 
-. Go to *Manage > Defenders > Manage* and validate that Console has upgraded your Defenders.
+. Go to *Manage > Defenders > Manage* and validate that Console has upgraded your Defender.

--- a/compute/rn/release-information/release-notes-22-12.adoc
+++ b/compute/rn/release-information/release-notes-22-12.adoc
@@ -29,6 +29,7 @@ Review the https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-12/prisma-cl
 
 toc::[]
 
+[#cve-coverage-update]
 === CVE Coverage Update
 
 As part of the 22.12 release, Prisma Cloud has rolled out updates to its vulnerability data for Common Vulnerabilities and Exposures (CVEs) in the Intelligence Stream. The new additions are as follows:
@@ -47,7 +48,7 @@ CVEs were added to the Intelligence Stream on an average of 13 days before they 
 As an example, a Kubernetes CVE (CVE-2022-3172) was published on September 16, 2022. The CVE was added to the Prisma Cloud Intelligence stream on September 19, 2022. And at this time in December 2022, the CVE is still reserved in MITRE and not analyzed in NVD. 
 
 
-
+[#new-features-agentless-security]
 === New Features in Agentless Security
 
 //GH#36812
@@ -64,6 +65,7 @@ You can now onboard Oracle Cloud Infrastructure accounts for agentless scanning 
 
 image::36812-agentless-results.png[scale=20]
 
+[#new-features-core]
 === New Features in Core
 
 //GH#36823 ( PCC-727)
@@ -97,7 +99,7 @@ See the image details view in  the *Vulnerability Explorer* and *Radar* to deter
 
 image::rn-37326-vuln_explorer_image_details.png[scale=20]
 
-//GH#37465 [PCSUP-7446] 
+//GH#37465 [PCSUP-7446]
 ==== Support for More Registry Entries
 
 You can now add up to 19,999 registry entries to *Defend > Vulnerabilities > Images > Registry settings*. And on *Monitor > Vulnerabilities > Images > Registries*, view scan results for a maximum of 100,000 images.
@@ -380,7 +382,7 @@ For example: `./twistcli sandbox --token "token" --volume /opt/sandbox_testing_t
 You can view the scan results on the mounted volume and on "Monitor > Runtime > Image analysis sandbox". 
 In this example the output of the 3rd party testing tool will be written to the `/opt/sandbox_testing_tools/output.txt file` on the sandbox host.
 
-
+[#new-features-host-security]
 === New Features in Host Security
 
 //GH#28715
@@ -391,6 +393,7 @@ In addition, you can import the list of applications and versions from hosts in 
 
 image::application-host-control-compliance-rule.png[10%]
 
+[#new-features-serverless]
 === New Features in Serverless
 
 //GH#28934
@@ -402,6 +405,7 @@ The account ID column is added under *Defend/Monitor > Vulnerabilities/Complianc
 image::28934-accountid-filter-serverless.png[scale=25 ]
 NOTE: Existing customers won't see the Account ID until the customer's accounts are re-added to Prisma Cloud.
 
+[#new-features-waas]
 === New Features in WAAS
 
 //GH#36818
@@ -466,7 +470,7 @@ Out-Of-Band tab is split into Agentless that supports VPC traffic mirroring, Con
 
 *Monitor > Events > WAAS for out-of-band* is now changed to *Monitor > Events > WAAS for agentless*, and the out-of-band events are included along with the in-line events under *WAAS for containers*, *WAAS for App-Embedded*, *WAAS for hosts*, and *WAAS for serverless*.
 
-
+[#api-changes]
 === API Changes and New APIs
 
 //GH#28794
@@ -621,10 +625,12 @@ You can now add or edit up to 19,999 registry entries by using the following API
 * POST, api/vVERSION/settings/registry
 * PUT, api/vVERSION/settings/registry
 
+[#disa-stig-findings]
 === DISA STIG Scan Findings and Justifications
 
 Every https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-compute-edition-public-sector/Release_Findings[release], we perform an SCAP scan of the Prisma Cloud Compute Console and Defender images. The process is based upon the U.S. Air Force’s Platform 1 "Repo One" OpenSCAP scan of the Prisma Cloud Compute images. We compare our scan results to IronBank’s latest approved UBI8-minimal scan findings. Any discrepancies are addressed or justified.
 
+[#addressed-issues]
 === Addressed Issues
 
 //[GH#31120]
@@ -665,7 +671,7 @@ A new  "Compliance ID" column is added to indicate the compliance-related issues
 //[GH#30643]
 * Python package info is updated to include the path.
 
-
+[#backward-compatibility]
 === Backward Compatibility for New Features
 
 [options="header"]


### PR DESCRIPTION
## Reference
The TOC links do not jump to the right section.

## Reason
Missing anchors or incorrect anchors. The anchor names with an underscore do not work. Use a hyphen instead.

## POC
[Serverless Defender](https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition-admin/install/install_defender/install_serverless_defender)