### PR TITLE
[Maxwell - Compute AG: CWP-45386]: Update AWS CloudFormation Autoscaling template

### DIFF
--- a/compute/admin_guide/waas/deploy_waas/deployment_vpc_mirroring.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deployment_vpc_mirroring.adoc
@@ -18,9 +18,9 @@ NOTE: With the 22.12.427 version, WAAS Agentless Observers are automatically upg
 
 * Monitoring applications with WAAS agentless through VPC traffic mirroring is subject to limitations, quotas, and checksum offloading as defined in the  https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-limits.html[AWS documentation].
 
-* To configure WAAS agentless with AWS VPC traffic mirroring, apply the permission template ending in https://redlock-public.s3.amazonaws.com/waas/aws/agentless_app_firewall_autoscaling_permissions_template.json[agentless_app_firewall_autoscaling_permissions_template.json] to AWS CloudFormation console for your account. For detailed instructions on how to apply cloud formation templates, refer to the https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html[AWS documentation].
+* To configure WAAS agentless with AWS VPC traffic mirroring, apply the permission template ending in https://redlock-public.s3.amazonaws.com/waas/aws/agentless_app_firewall_permissions_template.json[agentless_app_firewall_permissions_template.json] to AWS CloudFormation console for your account. For detailed instructions on how to apply cloud formation templates, refer to the https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html[AWS documentation].
 +
-Amazon EC2 Autoscaling is integrated with this AWS CloudFormation permission template.
+Amazon EC2 Auto Scaling is integrated with this AWS CloudFormation permission template.
 +
 Edit the template and replace the "USER-agentless-app-firewall" value with the actual username that you want to grant these permissions.
 +

--- a/compute/admin_guide/waas/deploy_waas/deployment_vpc_mirroring.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deployment_vpc_mirroring.adoc
@@ -12,13 +12,15 @@ For each VPC traffic mirroring rule, a VPC Observer will be created in a VPC mac
 
 === Prerequisites
 
-* The version of Console and Observer is 22.06 or later.
+* The version of Console and Observer is 22.12 or later.
 
 NOTE: With the 22.12.427 version, WAAS Agentless Observers are automatically upgraded to match the Console version.
 
 * Monitoring applications with WAAS agentless through VPC traffic mirroring is subject to limitations, quotas, and checksum offloading as defined in the  https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-limits.html[AWS documentation].
 
-* To configure WAAS agentless with AWS VPC traffic mirroring, apply the permission template ending in https://redlock-public.s3.amazonaws.com/waas/aws/agentless_app_firewall_permissions_template.json[agentless_app_firewall_permissions_template.json] to AWS CloudFormation console for your account. For detailed instructions on how to apply cloud formation templates, refer to the https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html[AWS documentation].
+* To configure WAAS agentless with AWS VPC traffic mirroring, apply the permission template ending in https://redlock-public.s3.amazonaws.com/waas/aws/agentless_app_firewall_autoscaling_permissions_template.json[agentless_app_firewall_autoscaling_permissions_template.json] to AWS CloudFormation console for your account. For detailed instructions on how to apply cloud formation templates, refer to the https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html[AWS documentation].
++
+Amazon EC2 Autoscaling is integrated with this AWS CloudFormation permission template.
 +
 Edit the template and replace the "USER-agentless-app-firewall" value with the actual username that you want to grant these permissions.
 +


### PR DESCRIPTION
## Reference:
https://redlock.atlassian.net/browse/CWP-45386

## Dependency:
[x] [AWS CloudFormation template](https://redlock-public.s3.amazonaws.com/waas/aws/agentless_app_firewall_permissions_template.json) updated with AutoScaling policy.

## Verified:
By engineering on the ticket