### PR TITLE
update Twistlock Serverless Defender netcore/6.0 support to be consistent

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -24,7 +24,7 @@ See xref:../system_requirements.adoc#serverless_runtimes[system requirements] fo
 
 The following runtimes are supported for AWS Lambda:
 
-* C# (.NET Core) 3.1
+* C# (.NET Core) 3.1, 6.0
 * Java 8, 11
 * Node.js 12.x, 14.x
 * Python 3.6, 3.7, 3.8, 3.9


### PR DESCRIPTION
Going through Serverless Defense documentation I noticed that there is a contradiction between the NET Core support for AWS Lambda.  Can I get some review and make sure I understand what the support for NET 6 actually is?  If the support *is* for NET 6 then I'd like for this documentation to get updated to be consistent.

Here are the two locations in regards to NET Core/AWS Lambda support for TwistLock Serverless Defender:

![image](https://user-images.githubusercontent.com/5581662/224359339-5cf6c54e-3511-47b8-9f3b-0785536953e9.png)

![image](https://user-images.githubusercontent.com/5581662/224359402-ba813efe-0129-4347-be40-1e78041fa42e.png)
