### PR TITLE
Update install_serverless_defender.adoc

### DIFF
--- a/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_serverless_defender.adoc
@@ -26,7 +26,7 @@ The following runtimes are supported for AWS Lambda:
 
 * C# (.NET Core) 3.1
 * Java 8, 11
-* Node.js 12.x, 14.x
+* Node.js 12.x, 14.x, 16.x, 18.x
 * Python 3.6, 3.7, 3.8, 3.9
 * Ruby 2.7
 


### PR DESCRIPTION
According to the document below, NodeJS 16 and 18 are supported

https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-compute/install/system_requirements (Serverless Runtimes)

If that's the case, those should be specified in this document

