### PR TITLE
Rectifying incorrect command.

### DIFF
--- a/compute/admin_guide/install/install-gke-autopilot.adoc
+++ b/compute/admin_guide/install/install-gke-autopilot.adoc
@@ -11,7 +11,7 @@ GKE Autopilot clusters are using https://cloud.google.com/kubernetes-engine/docs
 
 . Use the following twistcli command to generate the YAML file for the GKE Autopilot deployment.
 +
-   $ <PLATFORM>/twistcli console export kubernetes \
+   $ <PLATFORM>/twistcli defender export kubernetes \
     --gke-autopilot \
     --cri \
     --cluster-address <console address> \


### PR DESCRIPTION
This is a Defender deployment. Hence, replacing the word "console" with "defender".

