### PR TITLE
[Compute API] v1-corrections-cURL-examples

### DIFF
--- a/api/descriptions/_ping/get.md
+++ b/api/descriptions/_ping/get.md
@@ -10,5 +10,5 @@ $ curl -k \
   -o /dev/null \
   -w "%{http_code}\n" \
   -X GET \
-  https://<CONSOLE>/api/v1/_ping
+  https://<CONSOLE>/api/v<VERSION>/_ping
 ```

--- a/api/descriptions/audits/incidents_download_get.md
+++ b/api/descriptions/audits/incidents_download_get.md
@@ -14,7 +14,7 @@ $ curl -k \
   -H 'Content-Type: text/csv' \
   -X GET \
   -o incidents.csv \
-  https://<CONSOLE>/api/v1/audits/incidents/download
+  https://<CONSOLE>/api/v<VERSION>/audits/incidents/download
 ```
 
 A successful response displays the status of the download.

--- a/api/descriptions/audits/kubernetes_download_get.md
+++ b/api/descriptions/audits/kubernetes_download_get.md
@@ -12,6 +12,6 @@ $ curl -k \
   -H 'Content-Type: text/csv' \
   -X GET \
   -o <kubernetes_audits.csv> \
-  "https://console:8083/api/v1/audits/kubernetes/download"
+  "https://<CONSOLE>/api/v<VERSION>/audits/kubernetes/download"
 ```
 

--- a/api/descriptions/audits/waas_host_download_get.md
+++ b/api/descriptions/audits/waas_host_download_get.md
@@ -12,5 +12,5 @@ $ curl -k \
   -H 'Content-Type: text/csv' \
   -X GET \
   -o <waas-host-audits.csv> \
-  "https://console:8083/api/v1/audits/firewall/app/host/download"
+  "https://console:8083/api/v<VERSION>/audits/firewall/app/host/download"
 ```

--- a/api/descriptions/containers/scan_post.md
+++ b/api/descriptions/containers/scan_post.md
@@ -8,5 +8,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X POST \
-  https://<CONSOLE>:8083/api/v1/containers/scan
+  https://<CONSOLE>/api/v<VERSION>/containers/scan
 ```

--- a/api/descriptions/defenders/id_delete.md
+++ b/api/descriptions/defenders/id_delete.md
@@ -16,9 +16,9 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X DELETE \
-  https://<CONSOLE>/api/v1/defenders/<HOSTNAME>
+  https://<CONSOLE>/api/v<VERSION>/defenders/<HOSTNAME>
 ```
 
-`<HOSTNAME>` is populated with a value returned from the `/api/v1/defenders/names` endpoint.
+`<HOSTNAME>` is populated with a value returned from the `/api/v<VERSION>/defenders/names` endpoint.
 
 **Note:** No response will be returned upon successful execution.

--- a/api/descriptions/defenders/id_features_post.md
+++ b/api/descriptions/defenders/id_features_post.md
@@ -8,6 +8,6 @@ $ curl -k \
   -H 'Content-Type: application/json' \
   -X POST \
   -d '{"proxyListenerType": "tcp", "registryScanner":"<true|false>", "serverlessScanner":"<true|false>"}' \
-  https://<CONSOLE>:8083/api/v1/defenders/<HOSTNAME>/features
+  https://<CONSOLE>/api/v<VERSION>/defenders/<HOSTNAME>/features
 ```
 

--- a/api/descriptions/defenders/id_restart_post.md
+++ b/api/descriptions/defenders/id_restart_post.md
@@ -7,5 +7,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X POST \
-  https://<CONSOLE>:8083/api/v1/defenders/<HOSTNAME>/restart
+  https://<CONSOLE>/api/v<VERSION>/defenders/<HOSTNAME>/restart
 ```

--- a/api/descriptions/policies/compliance_ci_serverless_put.md
+++ b/api/descriptions/policies/compliance_ci_serverless_put.md
@@ -16,7 +16,7 @@ All prebuilt checks and their IDs are shown under **Compliance actions**.
 Refer to the following example cURL command that overwrites all rules in your current policy with a new policy that has a single rule:
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/compliance/ci/serverless' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/compliance/ci/serverless' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/compliance_container_impacted_get.md
+++ b/api/descriptions/policies/compliance_container_impacted_get.md
@@ -15,7 +15,7 @@ The following cURL command returns a list of containers captured by `<RULE_NAME>
 $ curl -k \
   -u <USER> \
   -X GET \
-  'https://<CONSOLE>/api/v1/policies/compliance/container/impacted?ruleName=<RULE_NAME>'
+  'https://<CONSOLE>/api/v<VERSION>/policies/compliance/container/impacted?ruleName=<RULE_NAME>'
 ```
 
 A successful response contains a list of impacted containers by a rule within the context of the policy.

--- a/api/descriptions/policies/compliance_serverless_put.md
+++ b/api/descriptions/policies/compliance_serverless_put.md
@@ -14,7 +14,7 @@ For a full list of checks, go to **Defend > Compliance > Functions > Functions**
 All prebuilt checks and their IDs are shown under **Compliance actions**.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/compliance/serverless' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/compliance/serverless' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/compliance_vms_get.md
+++ b/api/descriptions/policies/compliance_vms_get.md
@@ -12,7 +12,7 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  'https://<CONSOLE>/api/v1/policies/compliance/vms'
+  'https://<CONSOLE>/api/v<VERSION>/policies/compliance/vms'
 ```
 
 A successful response returns a list of compliance rules in the policy.

--- a/api/descriptions/policies/compliance_vms_put.md
+++ b/api/descriptions/policies/compliance_vms_put.md
@@ -15,7 +15,7 @@ For a full list of checks, go to **Defend > Compliance > Hosts > VM images** in 
 All prebuilt checks and their IDs are shown under **Compliance actions**.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/compliance/vms' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/compliance/vms' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/firewall_app-embedded_put.md
+++ b/api/descriptions/policies/firewall_app-embedded_put.md
@@ -20,7 +20,7 @@ We recommend the following process:
 The following cURL command overwrites all rules in your current policy with a new policy that has a single rule.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/firewall/app/app-embedded' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/firewall/app/app-embedded' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/firewall_app_network_list_put.md
+++ b/api/descriptions/policies/firewall_app_network_list_put.md
@@ -13,7 +13,7 @@ To invoke this endpoint in the Console UI:
 Refer to the following example cURL command that updates a network list.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/firewall/app/network-list' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/firewall/app/network-list' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/firewall_network_container_get.md
+++ b/api/descriptions/policies/firewall_network_container_get.md
@@ -8,5 +8,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  "https://<CONSOLE>:8083/api/v1/policies/firewall/network"
+  "https://<CONSOLE>/api/v<VERSION>/policies/firewall/network"
 ```

--- a/api/descriptions/policies/firewall_network_entities_get.md
+++ b/api/descriptions/policies/firewall_network_entities_get.md
@@ -5,5 +5,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>:8083/api/v1/policies/firewall/network/entities
+  https://<CONSOLE>/api/v<VERSION>/policies/firewall/network/entities
 ```

--- a/api/descriptions/policies/policies.md
+++ b/api/descriptions/policies/policies.md
@@ -12,7 +12,7 @@ For more information about policy endpoints, see:
 
 ### How to Add / Update Policy Rules
 
-All of the `PUT /api/v1/policies/*` endpoints work similarly. 
+All of the `PUT /api/vVERSION/policies/*` endpoints work similarly. 
 
 To add, edit, or remove vulnerability rules from a policy:
 
@@ -40,8 +40,8 @@ To add, edit, or remove vulnerability rules from a policy:
      -u <USER> \
      -X PUT \
      -H "Content-Type:application/json" \
-     https://<CONSOLE>/api/v1/policies/runtime/host \
-     --data-binary "@vulnerability_rules.json"
+     'https://<CONSOLE>/api/v<VERSION>/policies/runtime/host \
+     --data-binary "@vulnerability_rules.json"'
    ```
 
 Any previously installed rules are overwritten.
@@ -58,7 +58,7 @@ To create or update a rule, specify the following:
 For example, to replace all the vulnerability rules for CI image deployments:
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/vulnerability/ci/images?project=<PROJECT>' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/ci/images?project=<PROJECT>' \
   -X PUT \
   -u <USER> \
   -H 'Content-Type: application/json' \
@@ -135,7 +135,7 @@ The value in `effect` a comma-separated list.
 The following curl command creates a single rule compliance policy for container images scanned in the CI pipeline:
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/compliance/ci/images' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/compliance/ci/images' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/runtime_app-embedded_post.md
+++ b/api/descriptions/policies/runtime_app-embedded_post.md
@@ -7,7 +7,7 @@ This endpoint maps to the **Add rule** button in **Defend > Runtime > App-Embedd
 The following cURL command adds a single rule to your policy.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/runtime/app-embedded' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/runtime/app-embedded' \
   -k \
   -X POST \
   -u <USER> \

--- a/api/descriptions/policies/runtime_app-embedded_put.md
+++ b/api/descriptions/policies/runtime_app-embedded_put.md
@@ -8,7 +8,7 @@ This endpoint maps to the **Add rule** button in **Defend > Runtime > App-Embedd
 The following cURL command overwrites all rules in your current policy with a new policy that has a single rule.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/runtime/app-embedded' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/runtime/app-embedded' \
   -k \
   -X PUT \
   -u <USER> \

--- a/api/descriptions/policies/vulnerability_coderepos_get.md
+++ b/api/descriptions/policies/vulnerability_coderepos_get.md
@@ -12,7 +12,7 @@ Refer to the following example cURL command:
 $ curl -k \
   -u <USER> \
   -X GET \
-  'https://<CONSOLE>/api/v1/policies/vulnerability/coderepos'
+  'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/coderepos'
 ```
 
 A successful response returns a list of vulnerability rules in the policy.

--- a/api/descriptions/policies/vulnerability_coderepos_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_coderepos_impacted_get.md
@@ -13,7 +13,7 @@ The following cURL command returns a list of code repositories captured by `<RUL
 ```bash
 $ curl -k \
   -u <USER> \
-  -X GET 'https://<CONSOLE>/api/v1/policies/vulnerability/coderepos/impacted?project=<PROJECT_NAME>&ruleName=<RULE_NAME>'
+  -X GET 'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/coderepos/impacted?project=<PROJECT_NAME>&ruleName=<RULE_NAME>'
 ```
 
 A successful response contains a list of impacted repositories by a rule within the context of the policy.

--- a/api/descriptions/policies/vulnerability_host_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_host_impacted_get.md
@@ -14,7 +14,7 @@ The following cURL command returns a list of code repositories captured by `RULE
 ```bash
 $ curl -k \
   -u <USER> \
-  -X GET 'https://<CONSOLE>/api/v1/policies/vulnerability/host/impacted?project={PROJECT_NAME}&ruleName={RULE_NAME}'
+  -X GET 'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/host/impacted?project={PROJECT_NAME}&ruleName={RULE_NAME}'
 ```
 
 A successful response contains a list of impacted hosts by a rule within the context of the policy.

--- a/api/descriptions/policies/vulnerability_images_get.md
+++ b/api/descriptions/policies/vulnerability_images_get.md
@@ -11,7 +11,8 @@ The following cURL command retrieves all rules in the policy.
 ```bash
 $ curl -k \
   -u <USER> \
-  -X GET 'https://<CONSOLE>/api/v1/policies/vulnerability/images?project=<PROJECT_NAME>'
+  -X GET \
+  "https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/images?project=<PROJECT_NAME>"
 ```
 
 A successful response contains a list of vulnerability rules in the policy.

--- a/api/descriptions/policies/vulnerability_images_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_images_impacted_get.md
@@ -13,7 +13,8 @@ The following cURL command returns a list of images caught by `<RULE_NAME>`.
 ```bash
 $ curl -k \
   -u <USER> \
-  -X GET 'https://<CONSOLE>/api/v1/policies/vulnerability/images/impacted?project=<PROJECT_NAME>&ruleName=<RULE_NAME>'
+  -X GET \
+  "https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/images/impacted?project=<PROJECT_NAME>&ruleName=<RULE_NAME>"
 ```
 
 A successful response contains a list of entities caught by a rule within the context of the policy.

--- a/api/descriptions/policies/vulnerability_vms_get.md
+++ b/api/descriptions/policies/vulnerability_vms_get.md
@@ -12,7 +12,7 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  'https://<CONSOLE>/api/v1/policies/vulnerability/vms?project=<PROJECT>'
+  'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/vms?project=<PROJECT>'
 ```
 
 A successful response returns a list of vulnerability rules in the policy.

--- a/api/descriptions/policies/vulnerability_vms_impacted_get.md
+++ b/api/descriptions/policies/vulnerability_vms_impacted_get.md
@@ -14,7 +14,7 @@ The following cURL command returns a list of code repositories captured by `<RUL
 ```bash
 $ curl -k \
   -u <USER> \
-  -X GET 'https://<CONSOLE>/api/v1/policies/vulnerability/vms?project=<PROJECT_NAME>&ruleName=<RULE_NAME>'
+  -X GET 'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/vms?project=<PROJECT_NAME>&ruleName=<RULE_NAME>'
 ```
 
 A successful response contains a list of impacted repositories by a rule within the context of the policy.

--- a/api/descriptions/policies/vulnerability_vms_put.md
+++ b/api/descriptions/policies/vulnerability_vms_put.md
@@ -9,7 +9,7 @@ This endpoint maps to the policy table in **Defend > Vulnerabilities > Hosts > V
 The following cURL command overwrites all rules in your current policy with a new policy that has a single rule.
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/policies/vulnerability/vms?project=<PROJECT_NAME>' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/policies/vulnerability/vms?project=<PROJECT_NAME>' \
   -X PUT \
   -u <USER> \
   -H 'Content-Type: application/json' \

--- a/api/descriptions/profiles/container_learn_post.md
+++ b/api/descriptions/profiles/container_learn_post.md
@@ -10,5 +10,5 @@ $ curl -k -G \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X POST \
-  https://<CONSOLE>/api/v1/profiles/container/learn
+  https://<CONSOLE>/api/v<VERSION>/profiles/container/learn
 ```

--- a/api/descriptions/scans/download_get.md
+++ b/api/descriptions/scans/download_get.md
@@ -11,7 +11,7 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>/api/v1/scans/download \
+  https://<CONSOLE>/api/v<VERSION>/scans/download \
   > scans_report.csv
 ```
 

--- a/api/descriptions/scans/id_get.md
+++ b/api/descriptions/scans/id_get.md
@@ -2,10 +2,10 @@ Retrieves all scan reports for images scanned by the Jenkins plugin or twistcli 
 
 The following example curl command uses basic auth to retrieve the scan report for just an image with a SHA256 ID of `5c3385fd2e76c5c16124c077`.
  
-```
+```bash
 $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>:8083/api/v1/scans/5c3385fd2e76c5c16124c077
+  "https://<CONSOLE>/api/v<VERSION>/scans/5c3385fd2e76c5c16124c077"
 ```

--- a/api/descriptions/serverless/names_get.md
+++ b/api/descriptions/serverless/names_get.md
@@ -5,5 +5,5 @@ $ curl -k \
   -X GET \
   -H "Content-Type: application/json" \
   -u <USER> \
-  http://<CONSOLE>:8083/api/v1/serverless/names \
+  http://<CONSOLE>/api/v<VERSION>/serverless/names \
 ```

--- a/api/descriptions/settings/registry_get.md
+++ b/api/descriptions/settings/registry_get.md
@@ -21,5 +21,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  'https://<CONSOLE>/api/v1/settings/registry'
+  'https://<CONSOLE>/api/v<VERSION>/settings/registry'
 ```

--- a/api/descriptions/settings/registry_put.md
+++ b/api/descriptions/settings/registry_put.md
@@ -76,7 +76,7 @@ The following cURL command overwrites the current list of registries to scan wit
 * All repositories in a private AWS ECR registry
 
 ```bash
-$ curl 'https://<CONSOLE>/api/v1/settings/registry' \
+$ curl 'https://<CONSOLE>/api/v<VERSION>/settings/registry' \
   -k \
   -X PUT \
   -u <USER> \
@@ -126,5 +126,5 @@ curl -k \
   -H 'Content-Type: application/json' \
   -X PUT \
   -d '{"specifications":[]}' \
-  https://<CONSOLE>/api/v1/settings/registry
+  https://<CONSOLE>/api/v<VERSION>/settings/registry
 ```

--- a/api/descriptions/stats/daily_get.md
+++ b/api/descriptions/stats/daily_get.md
@@ -7,5 +7,5 @@ $ curl -k \
   -u <USER> \
   -H 'Content-Type: application/json' \
   -X GET \
-  https://<CONSOLE>:8083/api/v1/stats/daily
+  https://<CONSOLE>/api/v<VERSION>/stats/daily
 ```


### PR DESCRIPTION
There are total 35 instances of v1 in supported endpoints cURL examples that needed to be changed to vVERSION.