### PR TITLE
[Compute AG]: Fix broken xrefs

### DIFF
--- a/compute/admin_guide/install/install_defender/install_single_container_defender.adoc
+++ b/compute/admin_guide/install/install_defender/install_single_container_defender.adoc
@@ -12,10 +12,10 @@ Configure how a single Container Defender will be installed, and then install it
 
 *Prerequisites*:
 
-* Your system meets all minimum xref:../../install/system_requirements.adoc[system requirements].
+* Your system meets all minimum xref:../system_requirements.adoc[system requirements].
 * Ensure your host can access PCC through the network.
 ifdef::compute_edition[]
-** You have already xref:../../install/getting_started.adoc[installed PCC].
+** You have already xref:../getting_started.adoc[installed PCC].
 ** Port 8083 is open on the host where PCC runs.
 Port 8083 serves the API.
 Port 8083 is the default setting, but it is customizable when first installing PCC.
@@ -33,7 +33,7 @@ endif::prisma_cloud[]
 
 [.procedure]
 . Verify that the host machine where you install Defender can connect to the Prisma Cloud console.
-+
+
 ifdef::prisma_cloud[]
 .. Copy the path to the value under *Path to Console* from *Compute > Manage > System > Utilities*.
 .. Complete the following command with copied value.
@@ -58,7 +58,9 @@ curl -sk -D - <PATH-TO-CONSOLE>:8083/api/v1/_ping
 ----
 
 .. Run the command on your host system.
++
 If curl returns an HTTP response status code of 200, you have connectivity to PCC.
++
 If you customized the setup when you installed PCC, you might need to specify a different port.
 
 . Go to *Compute > Manage > Defenders > Deployed Defenders* and select *Manual deploy*.
@@ -73,8 +75,7 @@ image::install-defender-deploy-page.png[width=800]
 . Under *The name that Defender will use to connect to this Console*, select the correct item from the list of IP addresses and hostnames pre-populated in the drop-down list.
 
 ifdef::compute_edition[]
-If none of the items are valid, xref:../../configure/subject_alternative_names.adoc[add a new Subject Alternative Name (SAN)] to Prisma Cloud.
-After adding a SAN, your IP address or hostname will be available in the drop-down list.
+* If none of the items are valid, xref:../../configure/subject_alternative_names.adoc[add a new Subject Alternative Name (SAN)] to Prisma Cloud. After adding a SAN, your IP address or hostname will be available in the drop-down list.
 +
 [NOTE]
 ====
@@ -121,9 +122,9 @@ endif::compute_edition[]
 
 *Prerequisites*:
 
-* Your system meets all minimum xref:../../install/system_requirements.adoc[system requirements].
+* Your system meets all minimum xref:../system_requirements.adoc[system requirements].
 ifdef::compute_edition[]
-** You have already xref:../../install/getting_started.adoc[installed the Prisma Cloud Console (PCC)].
+** You have already xref:../getting_started.adoc[installed the Prisma Cloud Console (PCC)].
 ** Port 8083 is open on the host where PCC runs.
 Port 8083 serves the API.
 Port 8083 is the default setting, but it is customizable when first installing Console.
@@ -144,7 +145,7 @@ twistcl uses the service account to access PCC.
 [.procedure]
 
 . Verify that the host where you install Defender can connect to the Prisma Cloud console.
-+
+
 ifdef::prisma_cloud[]
 .. Replace `<PATH-TO-CONSOLE>` with the path found under *Path to Console* from *Compute > Manage > System > Utilities*.
 .. Verify connectivity with the following command.
@@ -166,6 +167,7 @@ curl -sk -D - <PATH-TO-CONSOLE>:8083/api/v1/_ping
 ----
 +
 If curl returns an HTTP response status code of 200, you have connectivity to PCC.
++
 If you customized the setup when you installed PCC, you might need to specify a different port.
 endif::compute_edition[]
 


### PR DESCRIPTION
## Description

Fix broken xref errors in [Install a single defender](https://docs.paloaltonetworks.com/prisma/prisma-cloud/22-12/prisma-cloud-compute-edition-admin/install/install_defender/install_single_container_defender).