### PR TITLE
[CSPM AG] Update to match AWS UI change

### DIFF
--- a/cspm/admin-guide/prisma-cloud-data-security/enable-data-security-module/enable-data-security-for-aws-org-account.adoc
+++ b/cspm/admin-guide/prisma-cloud-data-security/enable-data-security-module/enable-data-security-for-aws-org-account.adoc
@@ -151,7 +151,7 @@ image::pcds-aws-org-cloudtrail-6.png[scale=40]
 +
 image::pcds-aws-org-cloudtrail-7.png[scale=40]
 
-.. Under *Data events*, select *S3* as *Data event source* and select the *Write* checkbox for *All current and future S3 buckets*.
+.. Select *Switch to basic event selector*, and Under *Data events*, select *S3* as *Data event source* and select the *Write* checkbox for *All current and future S3 buckets*.
 +
 image::pcds-aws-org-cloudtrail-8.png[scale=40]
 


### PR DESCRIPTION
Comment on Slack on March 27, 2022 from Dennis Schmidt. Changes  On Step 4.8, the AWS console changed to default to the "advanced event selectors".  To follow the instructions as is, the user would first need to click the button "Switch to basic event selectors" to see the screen in the doc.  If the user tries to do the same steps with the advanced selectors, it will not work as expected.  It's clear from the screenshot that the basic selector is required - perhaps just note to indicate to switch to basic if on advanced.

