### PR TITLE
update vm_images.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
+++ b/compute/admin_guide/vulnerability_management/vm_image_scanning.adoc
@@ -61,6 +61,7 @@ To restrict permissions for creating and deleting resources, you can use conditi
 ====
 
 
+
 === Azure
 
 Prisma Cloud supports the following image types:


### PR DESCRIPTION
Add a note/blurb that current behavior will halt an entire scan if 1 image in the scope fails to scan .This is current behavior , we get cases on it and it's a feature level fix but it's not made aware to customers in any way.

I don't know the best place to add this content here-

