### PR TITLE
Update prisma_cloud_vulnerability_feed.adoc

### DIFF
--- a/compute/admin_guide/vulnerability_management/prisma_cloud_vulnerability_feed.adoc
+++ b/compute/admin_guide/vulnerability_management/prisma_cloud_vulnerability_feed.adoc
@@ -81,9 +81,6 @@ This analysis augments existing vulnerability detection and blocking mechanisms,
 ==== Supported apps
 
 The type of applications supported in the IS are:
-ifdef::compute_edition[]
-xref:../tools/update_intel_stream_offline.adoc#[Download IS data] and read the `cve.json` file to get the most recent list of packages.
-endif::compute_edition[]
 
 * .NET Core
 * ASP.NET Core


### PR DESCRIPTION
The contents of the IS feed are proprietary and should not be referenced directly. I've removed the reference to that data.

