### PR TITLE
[Compute AG]: Fix Auto defend missing page

### DIFF
--- a/compute/admin_guide/book_compute_edition.yml
+++ b/compute/admin_guide/book_compute_edition.yml
@@ -99,12 +99,12 @@ topics:
   - name: Deploy Host Defender
     dir: host
     topics:
-    - name: Auto-defend Hosts
-      file: auto-defend-host.adoc
     - name: Install a single Host Defender
       file: host.adoc
     - name: Windows Defender
       file: windows-host.adoc
+    - name: Auto-defend Hosts
+      file: auto-defend-host.adoc
   - name: Deploy Orchestrator Defender
     dir: orchestrator
     topics:

--- a/compute/admin_guide/book_prisma_cloud.yml
+++ b/compute/admin_guide/book_prisma_cloud.yml
@@ -76,12 +76,12 @@ topics:
   - name: Deploy Host Defender
     dir: host
     topics:
-    - name: Auto-defend Hosts
-      file: auto-defend-host.adoc
     - name: Install a single Host Defender
       file: host.adoc
     - name: Windows Defender
       file: windows-host.adoc
+    - name: Auto-defend Hosts
+      file: auto-defend-host.adoc
   - name: Deploy Orchestrator Defender
     dir: orchestrator
     topics:

--- a/compute/admin_guide/install/deploy-defender/host/auto-defend-host.adoc
+++ b/compute/admin_guide/install/deploy-defender/host/auto-defend-host.adoc
@@ -96,7 +96,7 @@ Add the following policy to an IAM user or role:
 [#azure-vms]
 === Azure virtual machines
 
-Prisma Cloud uses the Azure VM agent https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command)[Run Command] option to invoke the script to deploy Host defenders.
+Prisma Cloud uses the Azure VM agent https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command[Run Command] option to invoke the script to deploy Host defenders.
 You are required to configure the permissions below in your subscription and create host deploy rules to begin installing Defenders.
 
 
@@ -118,13 +118,13 @@ Also, run command is only supported on Linux VMs.
 
 ===== Required permissions
 
-In addition to the  https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)[Reader] role to get the list and details of the virtual machines, the Azure credential user needs permissions to invoke the runcommand.
+In addition to the  https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader[Reader] role to get the list and details of the virtual machines, the Azure credential user needs permissions to invoke the runcommand.
 
 ----
 Microsoft.Compute/virtualMachines/runCommand/action
 ----
 
-Typically,  the Virtual Machine https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor)[Contributor] role and higher levels have this permission. You can either directly use the role or create a custom role with the above permission.
+Typically,  the Virtual Machine https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor[Contributor] role and higher levels have this permission. You can either directly use the role or create a custom role with the above permission.
 
 [#gcp-compute]
 === GCP Compute Engine instances


### PR DESCRIPTION
## Description

Missing Auto Defend hosts page that leads to broken 404 error page.
<img width="262" alt="Screenshot 2023-04-24 at 12 24 25 PM" src="https://user-images.githubusercontent.com/11659160/233921137-f0704af2-131b-44c8-bb82-11f64349f06a.png" width="200">



<img width="473" alt="Screenshot 2023-04-24 at 11 11 43 AM" src="https://user-images.githubusercontent.com/11659160/233920222-ea107677-a062-46ff-b4c9-a6e9252e03ee.png">

## POC
The PDF generated with this fix now has the Auto Defend hosts page and the link from the Manage your Defenders to this page works.
<img width="354" alt="Screenshot 2023-04-24 at 12 14 38 PM" src="https://user-images.githubusercontent.com/11659160/233920182-66e8abe3-807b-4c11-9958-c5e64ddcf485.png">
