### PR TITLE
CWP-47798-API-Rate-Limit

### DIFF
--- a/api/descriptions/containers/get.md
+++ b/api/descriptions/containers/get.md
@@ -1,5 +1,8 @@
 Retrieves container scan reports.
 
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
 This endpoint maps to **Monitor > Compliance > Images > Deployed** in the Console UI.
 
 Refer to the following available options for the `fields` query parameters:
@@ -8,7 +11,6 @@ Refer to the following available options for the `fields` query parameters:
 * cluster
 * hostname
 * image
-
 ### cURL Request
 
 Refer to the following example cURL command that retrieves a scan report for all containers:

--- a/api/descriptions/hosts/get.md
+++ b/api/descriptions/hosts/get.md
@@ -1,4 +1,7 @@
-Retrieves all host scan reports. 
+Retrieves all host scan reports.
+
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
 
 This endpoint maps to the **Running hosts** table in **Monitor > Vulnerabilities > Hosts > Running hosts** in the Console UI.
 

--- a/api/descriptions/images/get.md
+++ b/api/descriptions/images/get.md
@@ -1,8 +1,11 @@
 Retrieves image scan reports.
 
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
 This endpoint maps to the image table in **Monitor > Compliance > Images > Deployed** in the Console UI.
 
-NOTE: The `image` object of the response was created for internal use of Prisma Cloud Compute for image scanning and analysis. Therefore, its inner fields are not saved in the database and will return empty in the endpoint response. You can get some of its values, such as `labels` and `history`, from the main structure of the response.
+> _**Note:**_ The `image` object of the response was created for internal use of Prisma Cloud Compute for image scanning and analysis. Therefore, its inner fields are not saved in the database and will return empty in the endpoint response. You can get some of its values, such as `labels` and `history`, from the main structure of the response.
 
 Consider the following available options to retrieve when you use the `fields` query parameter:
 - labels
@@ -11,7 +14,6 @@ Consider the following available options to retrieve when you use the `fields` q
 - clusters
 - hosts
 - repoTag.tag
-
 ### cURL Request
 
 Refer to the following cURL command that retrieves a compact scan report for all images:

--- a/api/descriptions/registry/get.md
+++ b/api/descriptions/registry/get.md
@@ -1,8 +1,11 @@
 Retrieves registry image scan reports.
 
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
 This endpoint maps to **Monitor > Compliance > Images > Registries** in the Console UI.
 
-**Note:** In the Console UI, the images can be found in **Monitor > Vulnerabilities > Images > Registries**.
+> _**Note:**_ In the Console UI, the images can be found in **Monitor > Vulnerabilities > Images > Registries**.
 
 Consider the following available options to retrieve when you use the `fields` query parameter:
 - labels

--- a/api/descriptions/scans/get.md
+++ b/api/descriptions/scans/get.md
@@ -1,5 +1,8 @@
 Retrieves all scan reports for images scanned by the Jenkins plugin or twistcli.
 
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
 This endpoint maps to **Monitor > Vulnerabilities > Images > CI** in the Console UI.
 
 ### cURL Request

--- a/api/descriptions/serverless/get.md
+++ b/api/descriptions/serverless/get.md
@@ -1,5 +1,8 @@
 Retrieves all scan reports for the serverless functions which Prisma Cloud has been configured to scan.
 
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
 This endpoint maps to **Monitor > Vulnerabilities > Functions > Scanned functions** in the Console UI.
 
 ### cURL Request

--- a/api/descriptions/vms/get.md
+++ b/api/descriptions/vms/get.md
@@ -1,6 +1,9 @@
 Returns all VM image scan reports.
 
-**Note**: This endpoint maps to the table in **Monitor > Vulnerabilities > Hosts > VM images** in the Prisma Cloud Compute.
+> _**Note:**_ The API rate limit for this endpoint is 30 requests per minute.
+You'll see an HTTP error response 429 if the limit exceeds.
+
+This endpoint maps to the table in **Monitor > Vulnerabilities > Hosts > VM images** in the Prisma Cloud Compute.
 
 ### cURL Request
 


### PR DESCRIPTION
Added information about the API rate limit for the seven supported endpoints.