### PR TITLE
fix curl example for CSPM authentication

### DIFF
--- a/cspm/admin-guide/get-started-with-prisma-cloud/access-the-prisma-cloud-api.adoc
+++ b/cspm/admin-guide/get-started-with-prisma-cloud/access-the-prisma-cloud-api.adoc
@@ -18,9 +18,9 @@ Note that you must use the https://pan.dev/prisma-cloud/api/cspm/api-urls/[API U
 [userinput]
 ----
 curl --request POST \
-'https://api.prismacloud.io/login' \
--H 'Content-Type: application/json' \
--data '{"username":"<Access Key ID>","password":"<Secret Key>"}'
+  'https://api.prismacloud.io/login' \
+  -H 'Content-Type: application/json' \
+  --data '{"username":"<Access Key ID>","password":"<Secret Key>"}'
 ----
 +
 The following shows the response for a successful request.


### PR DESCRIPTION
single dash `-data` was being handled as `-d "ata"`, rather than the correct `--data <argument>`.
