### PR TITLE
[Compute AG] licensing updates

### DIFF
--- a/compute/admin_guide/welcome/licensing.adoc
+++ b/compute/admin_guide/welcome/licensing.adoc
@@ -70,11 +70,10 @@ For this type of deployment, a Serverless Defender is embedded into each functio
 
 === Workload fluctuation
 
-Credit consumption is measured using a 30 day rolling average.
+Credit consumption is measured hourly and the hourly samples are averaged to create daily samples.
 To determine if you’re within your licensed coverage, the rolling average is compared to the number of credits in your license.
 
-Prisma Cloud samples the number of protected nodes hourly, then creates a daily average based on these samples.
-The preceding 30 daily averages are averaged to determine the credit consumption.
+The credit usage for a specified time range uses the appropriate hourly, daily or monthly average. 
 If there is less than 30 days of data available, the average is calculated using the days available.
 
 *Example*: Assume you've licensed 700 credits to cover 100 container hosts, and usage fluctuates from week to week:


### PR DESCRIPTION
removed references to  "30 day rolling average" based on feedback on Slack (may 17) from Walter, who confirmed with Steve J

