### PR TITLE
Update install-gke-autopilot.adoc

### DIFF
--- a/compute/admin_guide/install/deploy-defender/orchestrator/install-gke-autopilot.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/install-gke-autopilot.adoc
@@ -15,10 +15,12 @@ Defenders deployed on GKE Autopilot clusters only support the official twistlock
    $ <PLATFORM>/twistcli defender export kubernetes \
     --gke-autopilot \
     --cri \
-    --cluster-address <console address> \
-    --address https://<console address>:8083
+    --cluster-address <console address>:443 \
+    --address https://<console address>
 +
 The `--gke autopilot flag adds the 'autopilot.gke.io/no-connect: "true"`' annotation to the YAML file and `--cri` flag enables the CRI option for nodes that use the Container Runtime Interface (CRI), not Docker. It also removes the  '/var/lib/containers' mount from the generated file as that configuration is not required for the GKE autopilot deployment.
+
+The console address can be obtained from Compute->Manage->System->Utilities->Path to Console
 +
 [NOTE]
 ====


### PR DESCRIPTION
We need to remove port 8083, because this is not self hosted. We also need to add port 443 to the cluster address (which is used for the defenders to point to the console via WSS protocol).

Finally, we should add a note to explain where this console address is coming from

