### PR TITLE
Update guidelines-for-optimizing-data-security-cost.adoc

### DIFF
--- a/cspm/admin-guide/prisma-cloud-data-security/guidelines-for-optimizing-data-security-cost.adoc
+++ b/cspm/admin-guide/prisma-cloud-data-security/guidelines-for-optimizing-data-security-cost.adoc
@@ -24,7 +24,9 @@
 
 * The data that is downloaded from your storage systems are not persisted anywhere on the Prisma Cloud infrastructure and is only held for the duration of processing of the content for Data Profile analysis or limited by a maximum time out limit (24 hrs), whichever is hit earlier.
 
-* There will be egress cost implications for you as Prisma Cloud Data Security evaluates all content in your S3 buckets. You can choose to optimize on cost by only selecting those buckets requiring scans and filtering out any known good files that would not require any Data Profile analysis or malware analysis, such as Database backup files.
+* When evaluating the content of your S3 buckets, the solution uses workers which resides in the respective region. As a result, data transfer from your S3 bucket to the worker happens within the same region and there shouldn't be any egress cost implication on your side.
+
+* You can choose to optimize on the credits usage by only selecting those buckets requiring scans and filtering out any known good files that would not require any Data Profile analysis or malware analysis, such as Database backup files.
 
 
 


### PR DESCRIPTION
The last bullet point is inaccurate:

* There will be egress cost implications for you as Prisma Cloud Data Security evaluates all content in your S3 buckets. You can choose to optimize on cost by only selecting those buckets requiring scans and filtering out any known good files that would not require any Data Profile analysis or malware analysis, such as Database backup files.


PCDS workers which download S3 data reside in the respective region as the S3 bucket. Per AWS S3 data transfer pricing https://aws.amazon.com/s3/pricing , 
```
You pay for all bandwidth into and out of Amazon S3, except for the following:
- Data transferred from an Amazon S3 bucket to any AWS service(s) within the same AWS Region as the S3 bucket (including to a different account in the same AWS Region).
```
So, there shouldn't be any egress cost implication on the customer side when PCDS downloads and evaluates the content of the S3 bucket.
