### PR TITLE
[Compute AG: CWP-47516]: K8s CrashLoopBackOff error

### DIFF
--- a/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
@@ -199,20 +199,36 @@ include::install_kubernetes_cri.adoc[leveloffset=+1]
   
   Back-off restarting failed container
 
+To get the error logs, run the command: `kubectl describe pod[name]`.
+
 **Reason**
 
-<placeholder>
+This is caused due to a temporary memory resource overload.
+When running WAAS Out-of-Band (OOB), the Defender automatically increases the `cgroup` memory limit to 4 GB (As, OOB needs more memory). But since the Defenders' `cgroup` in K8s is hierarchically under the `cgroup` of the K8s pod with a limit of 512 MB, this results in an Out-Of-Memory error.
 
 [.task]
-=== Increase the Defender Pod Limit
+==== Increase the Defender Pod Limit
 
-Increase the Pod limit to 4 GB when activating WAAS OOB.
+Increase the Pod limit to 4 GB when activating WAAS OOB on K8s cluster.
 
 [.procedure]
 
-* **For running Defenders**
+. **For running Defenders**
+.. Run `kubectl edit ds twistlock-defender-ds -n twistlock` and change the value under *resources > limits > memory* to *4096Mi* in the Daemonset spec `*.yaml` file.
+.. *Save* the file to restart the Defenders with the increased memory limit.
 
-* **When deploying Defenders**
+. **When deploying Defenders**
+.. *With `.yaml` file*:
+... Change the value of *resources > limits > memory* to *4096Mi*.
+... Deploy the `*.yaml` file.
+
+.. *With HELM*:
+... Change the value of *limit_memory* to *4096Mi* in "values.yaml" file.
+
+.. *With script*:
+... Deploy the Defender using the install script.
+... Run `kubectl edit ds twistlock-defender-ds -n twistlock` and change the value under *resources > limits > memory* to *4096Mi*.
+... *Save* the file to restart the Defenders with the increased memory limit.
 
 ==== Pod Security Policy
 If Pod Security Policy is enabled in your cluster, you might get the following error when trying to create a Defender DaemonSet.

--- a/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
@@ -218,7 +218,7 @@ Increase the Pod limit to 4 GB when activating WAAS OOB on K8s cluster.
 .. *Save* the file to restart the Defenders with the increased memory limit.
 
 . **When deploying Defenders**
-.. *With `.yaml` file*:
+.. *With YAML*:
 ... Change the value of *resources > limits > memory* to *4096Mi*.
 ... Deploy the `*.yaml` file.
 

--- a/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
@@ -193,6 +193,27 @@ include::install_kubernetes_cri.adoc[leveloffset=+1]
 
 === Troubleshooting
 
+==== Kubernetes CrashLoopBackOff Error
+
+**Error**
+  
+  Back-off restarting failed container
+
+**Reason**
+
+<placeholder>
+
+[.task]
+=== Increase the Defender Pod Limit
+
+Increase the Pod limit to 4 GB when activating WAAS OOB.
+
+[.procedure]
+
+* **For running Defenders**
+
+* **When deploying Defenders**
+
 ==== Pod Security Policy
 If Pod Security Policy is enabled in your cluster, you might get the following error when trying to create a Defender DaemonSet.
 

--- a/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
@@ -204,7 +204,7 @@ To get the error logs, run the command: `kubectl describe pod[name]`.
 **Reason**
 
 This is caused due to a temporary memory resource overload.
-When running WAAS Out-of-Band (OOB), the Defender automatically increases the `cgroup` memory limit to 4 GB (As, OOB needs more memory). But since the Defenders' `cgroup` in K8s is hierarchically under the `cgroup` of the K8s pod with a limit of 512 MB, this results in an Out-Of-Memory error.
+When running WAAS Out-of-Band (OOB), the Defender automatically increases the `cgroup` memory limit to 4 GB (as OOB needs more memory). But since the Defenders' `cgroup` in K8s is hierarchically under the `cgroup` of the K8s pod with a limit of 512 MB, this results in an Out-Of-Memory error.
 
 [.task]
 ==== Increase the Defender Pod Limit

--- a/compute/admin_guide/waas/deploy_waas/deploy_oob_containers.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deploy_oob_containers.adoc
@@ -16,6 +16,7 @@ To deploy WAAS for Out-Of-Band network traffic, create a new rule, define applic
 [.procedure]
 :waas_containers:
 :waas_oob:
+:waas_oob_containers:
 include::fragments/create-waas-rule.adoc[leveloffset=0]
 
 [.task]

--- a/compute/admin_guide/waas/deploy_waas/deploy_oob_containers.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deploy_oob_containers.adoc
@@ -5,7 +5,6 @@ Create a new rule to deploy WAAS xref:../waas-intro.adoc#_waasoob[Out-Of-Band] f
 === Prerequisites
 
 * You have xref:../../install/deploy-defender/defender_types.adoc#[installed a Container Defender] in your workload environment.
-* The minimum version of Console and Defender is 22.12. 
 * A TLS certificate in PEM format.
 
 [.task]

--- a/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
+++ b/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
@@ -44,7 +44,8 @@ WAAS only needs to be applied to hosts that run applications that transmit and r
 endif::waas_hosts[]
 ifdef::waas_oob_containers[]
 +
-NOTE: When deploying WAAS OOB on K8s cluster, increase the `cgroup` limit to 4 GB to avoid https://docs.paloaltonetworks.com/prisma/prisma-cloud/30/prisma-cloud-compute-edition-admin/install/deploy-defender/orchestrator[Kubernetes CrashLoopBackOff Error].
+NOTE: When deploying WAAS OOB on K8s cluster, increase the `cgroup` limit to 4 GB to avoid 
+xref:../../install/deploy-defender/orchestrator/orchestrator.adoc[Kubernetes CrashLoopBackOff Error].
 endif::waas_oob_containers[]
 
 . (Optional) Enable *API endpoint discovery*

--- a/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
+++ b/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
@@ -42,6 +42,10 @@ endif::waas_oob_hosts[]
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.
 endif::waas_hosts[]
+ifdef::waas_oob_containers[]
++
+NOTE: When deploying WAAS OOB on K8s cluster, increase the `cgroup` limit to 4 GB to avoid https://docs.paloaltonetworks.com/prisma/prisma-cloud/30/prisma-cloud-compute-edition-admin/install/deploy-defender/orchestrator[Kubernetes CrashLoopBackOff Error].
+endif::waas_oob_containers[]
 
 . (Optional) Enable *API endpoint discovery*
 +


### PR DESCRIPTION
## Reference

[CWP-47516](https://redlock.atlassian.net/browse/CWP-47516)
[PCSUP-15640](https://redlock.atlassian.net/browse/PCSUP-15640)

## Description

- [x] Update Troubleshooting section in Orchestor.adoc file
- [x] Link the WAAS OOB deployment section to Orchestrator troubleshooting section.
- [x] Add a new column under “Prisma Cloud Console Resource Requirements on x86_64” on [System Requirements](https://docs.paloaltonetworks.com/prisma/prisma-cloud/30/prisma-cloud-compute-edition-admin/install/system_requirements) page:

## Reviewed

- [x] The draft on the troubleshooting section needs to be verified by the Engineering and verified on the ticket.

## Blocked by

- [x] Need confirmation on System Requirements page. - Engg. confirmed in the doc that only memory to be updated as 4 GB and we leave the CPU and storage values as blank. Updated the same in the Maxwell System requirements sheet.

