### PR TITLE
[CWP Public Sector] Fix book.yml

### DIFF
--- a/compute/public_sector/book.yml
+++ b/compute/public_sector/book.yml
@@ -52,27 +52,27 @@ topics:
   dir: v22_12_415
   topics:
   - name: Scan results
-    file: V22_12_415.adoc
+    file: v22_12_415.adoc
 - name: 22.06.224
   dir: v22_06_224
   topics:
   - name: Scan results
-    file: V22_06_224.adoc
+    file: v22_06_224.adoc
 - name: 22.06.197
   dir: v22_06_197
   topics:
   - name: Scan results
-    file: V22_06_197.adoc
+    file: v22_06_197.adoc
 - name: 22.06.179
   dir: v22_06_179
   topics:
   - name: Scan results
-    file: V22_06_179.adoc
+    file: v22_06_179.adoc
 - name: 22.01.880
   dir: v22_01_880
   topics:
   - name: Scan results
-    file: V22_01_880.adoc
+    file: v22_01_880.adoc
 - name: 22.01.840
   dir: v22_01_840
   topics:


### PR DESCRIPTION
book.yml references files that were renamed. Update the references in book.yml.

