### PR TITLE
Fix tables in runtime_audits.adoc

### DIFF
--- a/compute/admin_guide/runtime_defense/runtime_audits.adoc
+++ b/compute/admin_guide/runtime_defense/runtime_audits.adoc
@@ -20,6 +20,9 @@ This document summarizes all the runtime audits (detections) that are available 
 |
 |Containers
 
+|Port Scanning
+|<INSERT PORT SCANNING CONTEXT HERE>
+
 |<process> launched and is identified as a process used for port scanning
 |xref:incident_types/port_scanning.adoc[Port scanning]
 |Containers
@@ -256,6 +259,9 @@ Containers
 
 * Enable and disable this detection through the *Port scanning* effects, under the Container runtime rule for Networking.
 * Avoid audits on specific known and allowed processes, by adding process names to the runtime rule processes *Allowed* list.
+|<INSERT PORT SCANNING AUDIT MESSAGE HERE>
+|<INSERT PORT SCANNING TRIGGER AN INCIDENT HERE>
+|<INSERT PORT SCANNING WORKLOADS HERE>
 
 |Explicitly Denied IP
 |Indicates that access to an IP address listed in the *Denied & fallback* list was detected.

--- a/compute/admin_guide/runtime_defense/runtime_audits.adoc
+++ b/compute/admin_guide/runtime_defense/runtime_audits.adoc
@@ -21,7 +21,7 @@ This document summarizes all the runtime audits (detections) that are available 
 |Containers
 
 |Port Scanning
-|<INSERT PORT SCANNING CONTEXT HERE>
+|Indicates a process was spawned, that is identified as being used for port scanning.
 
 |<process> launched and is identified as a process used for port scanning
 |xref:incident_types/port_scanning.adoc[Port scanning]
@@ -259,9 +259,9 @@ Containers
 
 * Enable and disable this detection through the *Port scanning* effects, under the Container runtime rule for Networking.
 * Avoid audits on specific known and allowed processes, by adding process names to the runtime rule processes *Allowed* list.
-|<INSERT PORT SCANNING AUDIT MESSAGE HERE>
-|<INSERT PORT SCANNING TRIGGER AN INCIDENT HERE>
-|<INSERT PORT SCANNING WORKLOADS HERE>
+|<process> launched and is identified as a process used for port scanning
+|xref:incident_types/port_scanning.adoc[Port scanning]
+|Containers
 
 |Explicitly Denied IP
 |Indicates that access to an IP address listed in the *Denied & fallback* list was detected.


### PR DESCRIPTION
Some cells are missing, causing mismatch in the tables : 
 - In 'Runtime detections for processes' table, two cells missing for 'Port Scanning' row : 'DETECTION' and 'CONTEXT' columns
 - In 'Runtime detections for Network activities' table, three cells missing in 'Port Scanning' row : 'AUDIT MESSAGE', 'TRIGGER AN INCIDENT', and 'WORKLOADS' columns

## Preview
<img width="743" alt="Screenshot 2023-09-05 at 5 18 17 PM" src="https://github.com/PaloAltoNetworks/prisma-cloud-docs/assets/11659160/2169597a-d245-4050-8d21-6eb94c045ebf">

