### PR TITLE
Update prisma-cloud-licenses.adoc

### DIFF
--- a/cspm/admin-guide/get-started-with-prisma-cloud/prisma-cloud-licenses.adoc
+++ b/cspm/admin-guide/get-started-with-prisma-cloud/prisma-cloud-licenses.adoc
@@ -24,7 +24,7 @@ To take advantage of these new modules, switch from a resource-block based meter
 ====
 A Developer seat refers to an active Git committer, identified as such through their unique Git author email address. Anyone that made a contribution to a code repo protected by Prisma Cloud within the last 90 days can also be considered a Developer.
 ====
-+
+
 With the Enterprise Edition, you can optionally upgrade to a premium success plan that includes 24x7 access to customer success experts, custom workshops, implementation assistance, configuration and planning, and best practices guides.
 
 Each of these offerings has a different capacity unit and unit price in Prisma Cloud Credits. The number of credits required to secure your assets can vary based on the offering and the size of your deployment. Refer to the https://www.paloaltonetworks.com/resources/guides/prisma-cloud-pricing-and-editions[Prisma Cloud Licensing and Editions Guide] for details. Licensing is sold in increments of 100 credits and you estimate the number of units you need to monitor and protect.
@@ -54,7 +54,9 @@ The zip file download is available for the standard plan only. It provides a gra
 ====
 
 
-* Consumption Trend Graph— The graph provides the overall view of your license consumption trends for the selected time period. You can review the average usage overlaid against the Prisma Cloud credits you have purchased and the actual credit usage trends. The usage trends can help you identify bursts in usage to meet short-term needs for your business and the steady usage as you accelerate or scale back in deploying assets in your cloud adoption journey.
+* Consumption Trend Graph— The graph provides the overall view of your license consumption trends for the selected time period. Credit consumption is measured hourly and the hourly samples are averaged to create daily samples. The credit usage for a specified time range uses the appropriate hourly, daily or monthly average. If there is less than 30 days of data available, the average is calculated using the days available.
++
+You can review the average usage overlaid against the Prisma Cloud credits you have purchased and the actual credit usage trends. The usage trends can help you identify bursts in usage to meet short-term needs for your business and the steady usage as you accelerate or scale back in deploying assets in your cloud adoption journey.
 +
 The average usage graph presents a daily average for up to a 6-month period, and monthly averages for 6 months to last 3-year term.
 


### PR DESCRIPTION
revised the details on 

Credit consumption is measured hourly and the hourly samples are averaged to create daily samples. The credit usage for a specified time range uses the appropriate hourly, daily or monthly average. If there is less than 30 days of data available, the average is calculated using the days available

This inline with https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/1210

