### PR TITLE
Update install_defender_twistcli_export_kubectl.adoc

### DIFF
--- a/compute/admin_guide/install/fragments/install_defender_twistcli_export_kubectl.adoc
+++ b/compute/admin_guide/install/fragments/install_defender_twistcli_export_kubectl.adoc
@@ -38,7 +38,7 @@ ifdef::prisma_cloud[]
 . Retrieve the hostname of the Prisma Cloud Console hostname to use as the value for `PRISMA_CLOUD_COMPUTE_HOSTNAME`.
 +
 The hostname can be derived from the URL by removing the protocol scheme and path.
-It is simply the host part of the URL. You can also retrieve the hostname directly.
+It is simply the host part of the URL. You can also retrieve the hostname directly by following Step 3-D below. 
 
 endif::prisma_cloud[]
 
@@ -60,17 +60,19 @@ endif::compute_edition[]
 +
 [source,bash]
 ----
-$ <PLATFORM>/twistcli defender export kubernetes \
-  --user <ADMIN_USER> \
+$ <PLATFORM>./twistcli defender export kubernetes \
+  --user <ADMIN_USER_ACCESS_KEY> \
   --address <PRISMA_CLOUD_COMPUTE_CONSOLE_URL> \
-  --cluster-address <PRISMA_CLOUD_COMPUTE_HOSTNAME>
-  --container-runtime crio
+  --cluster-address <PRISMA_CLOUD_COMPUTE_HOSTNAME> \ 
+  --container-runtime containerd
 ----
 +
 * <PLATFORM> can be `linux`, `osx`, or `windows`.
-* <ADMIN_USER> is the name of a Prisma Cloud user with the System Admin role.
+* <ADMIN_USER_ACCESS_KEY> is the access key of the Prisma Cloud user with the System Admin role.
 * <PRISMA_CLOUD_COMPUTE_CONSOLE_URL> specifies the address of the Prisma Cloud Compute Console.
 * <PRISMA_CLOUD_COMPUTE_HOSTNAME> specifies the address Defender uses to connect to Prisma Cloud Console. You can use the external IP address exposed by your load balancer or the DNS name that you manually set up.
+
+* Once you run the given command, after altering the fields for your environment, you will get a prompt requesting a password. The password is the secret key of the Prisma Cloud user with the System Admin role that you should have created as part of the prerequisite.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Defender Deployment Content Testing 
Revise twistcli command: 
--user <ADMIN_USER> 
to --user <ADMIN_USER_ACCESS_KEY> #Was confusing with SSO to tenants not allowing password, access keys are a better usage here

Add \, line continuation after --cluster-address, to interpret --container-runtime 

In the parameters below <ADMIN_USER_ACCESS_KEY>, detailed using access keys instead to simplify

