### PR TITLE
Update orchestrator.adoc

### DIFF
--- a/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
+++ b/compute/admin_guide/install/deploy-defender/orchestrator/orchestrator.adoc
@@ -23,6 +23,8 @@ To deploy your Defenders smoothly, you must meet the following requirements.
 
 * You have a valid Prisma Cloud license key and access token.
 
+* You have a valid access key and secret key created for the admin user inside Prisma Cloud 
+
 * You provisioned a Kubernetes cluster that meets the minimum xref:../../system_requirements.adoc[system requirements] and runs a xref:../../system_requirements.adoc#orchestrators[supported Kubernetes version].
 
 * You set up a Linux or macOS system to control your cluster, and you can access the cluster using the `kubectl` command-line utility.
@@ -122,17 +124,18 @@ The following procedure shows the modified commands.
 [.procedure]
 . Create a Defender `DaemonSet` Helm chart.
 
-  $ <PLATFORM>/twistcli defender export kubernetes \
+  $ <PLATFORM>./twistcli defender export kubernetes \
     --address https://yourconsole.example.com:8083 \
     --helm \
-    --user <ADMIN_USER> \
-    --cluster-address twistlock-console
+    --user <ADMIN_USER_ACCESS_KEY> \
+    --cluster-address twistlock-console \
+    --container-runtime containerd
 
 . Install the Defender.
 
-  $ helm install \
-    --create-namespace twistlock \
-    --name twistlock-defender-ds \
+  $ helm install twistlock-defender-ds \
+    --namespace twistlock \ 
+    --create-namespace \
     ./twistlock-defender-helm.tar.gz
 
 endif::prisma_cloud[]
@@ -163,7 +166,7 @@ The following procedure shows the modified commands.
 
   $ helm install twistlock-console \
     --namespace twistlock \
-    --create namespace \
+    --create-namespace \
     ./twistlock-console-helm.tar.gz
 
 . <<_configure_console,Configure Console>>.
@@ -173,14 +176,14 @@ The following procedure shows the modified commands.
   $ <PLATFORM>/twistcli defender export kubernetes \
     --address https://yourconsole.example.com:8083 \
     --helm \
-    --user <ADMIN_USER> \
+    --user <ADMIN_USER_ACCESS_KEY> \
     --cluster-address twistlock-console
 
 . Install the Defender.
 
   $ helm install twistlock-defender-ds \
     --namespace twistlock \
-    --create namespace \
+    --create-namespace \
     ./twistlock-defender-helm.tar.gz
 
 endif::compute_edition[]


### PR DESCRIPTION
Defender Deployment Content Testing 
Add prerequisite: You have a valid access key and secret key created for the admin user inside Prisma Cloud

Helmchart PCEE section: #for version 3.0+ now 
Step 1: Helm command requires --container-runtime 
Step 2: Helm 3.0+ deprecated --name flag

Helmchart PCCE: 
Fix missing "-" between --create namespace (--create-namespace)

