### PR TITLE
[PCEE RN] B/C sentence confusion and removal

### DIFF
--- a/compute/rn/release-information/release-notes-30-02-update2.adoc
+++ b/compute/rn/release-information/release-notes-30-02-update2.adoc
@@ -152,9 +152,7 @@ The `cri` boolean parameter (in the `common.DaemonSetOptions` schema) in the abo
 
     "type": "string"
 }
-----
-
-This change is applicable from the 30.02 release and is backward compatible. 
+---- 
 
 IMPORTANT: You must update existing scripts that use either of the two endpoints when you upgrade to 30.02 or a future release.
 

--- a/compute/rn/release-information/release-notes-30-02-update2.adoc
+++ b/compute/rn/release-information/release-notes-30-02-update2.adoc
@@ -119,38 +119,57 @@ The following APIs have been enhanced to include support for the containerd runt
 
 * POST, `/api/vVERSION/defenders/helm/twistlock-defender-helm.tar.gz`
 
-The `cri` boolean parameter (in the `common.DaemonSetOptions` schema) in the above endpoints has been replaced by the `common.ContainerRuntime` schema in the 30.02 release, as shown below:
+The `cri` boolean parameter (in the `common.DaemonSetOptions` schema) in the above endpoints has been replaced by the `common.ContainerRuntime` schema in the 30.02 release.
 
 *Old (30.01 and earlier releases)* 
 
+Example request schema showing *cri* set to a boolean value *true* for Docker and CRI-O:
+
 [source,json]
 ----
-"cri": {
-"description": "Indicates that Defender uses CRI instead of docker.\n",
-"type": "boolean"
+
+{
+    "consoleAddr":"171.23.0.1",
+    "namespace":"twistlock",
+    "orchestration":"kubernetes",
+    "selinux":false,
+    "cri":true,
+    "privileged":false,
+    "serviceAccounts":true,
+    "istio":false,
+    "collectPodLabels":false,
+    "proxy":null,
+    "taskName":null,
+    "gkeAutopilot":false
 }
+
 ----
 
 *New (in release 30.02)*
+
+From 30.02, you can set the following values for container runtime:
+
+* containerd
+* crio
+* docker
+
+Example request schema showing *cri* is replaced with *containerRuntime*:
+
 [source,json]
 ----
-"containerRuntime": 
 {
-    "$ref": "#/components/schemas/common.ContainerRuntime"
-},
-
-"common.ContainerRuntime": 
-{
-    "description": "Represents the supported container runtime types",
-    "enum": [
-                [
-                    "docker",
-                    "containerd",
-                    "crio"
-                ]
-            ],
-
-    "type": "string"
+    "consoleAddr":"171.23.0.1",
+    "namespace":"twistlock",
+    "orchestration":"kubernetes",
+    "selinux":false,
+    "containerRuntime":"containerd",
+    "privileged":false,
+    "serviceAccounts":true,
+    "istio":false,
+    "collectPodLabels":false,
+    "proxy":null,
+    "taskName":null,
+    "gkeAutopilot":false
 }
 ---- 
 

--- a/cspm/rn/prisma-cloud-compute-release-information/features-introduced-in-compute-june-2023.adoc
+++ b/cspm/rn/prisma-cloud-compute-release-information/features-introduced-in-compute-june-2023.adoc
@@ -148,9 +148,7 @@ The `cri` boolean parameter (in the `common.DaemonSetOptions` schema) in the abo
 
     "type": "string"
 }
-----
-
-This change is applicable from the 30.02 release and is backward compatible. 
+---- 
 
 IMPORTANT: You must update existing scripts that use either of the two endpoints when you upgrade to 30.02 or a future release.
 

--- a/cspm/rn/prisma-cloud-compute-release-information/features-introduced-in-compute-june-2023.adoc
+++ b/cspm/rn/prisma-cloud-compute-release-information/features-introduced-in-compute-june-2023.adoc
@@ -119,36 +119,55 @@ The `cri` boolean parameter (in the `common.DaemonSetOptions` schema) in the abo
 
 *Old (30.01 and earlier releases)* 
 
+Example request schema showing *cri* set to a boolean value *true* for Docker and CRI-O:
+
 [source,json]
 ----
-"cri": {
-"description": "Indicates that Defender uses CRI instead of docker.\n",
-"type": "boolean"
+
+{
+    "consoleAddr":"171.23.0.1",
+    "namespace":"twistlock",
+    "orchestration":"kubernetes",
+    "selinux":false,
+    "cri":true,
+    "privileged":false,
+    "serviceAccounts":true,
+    "istio":false,
+    "collectPodLabels":false,
+    "proxy":null,
+    "taskName":null,
+    "gkeAutopilot":false
 }
+
 ----
 
 *New (in release 30.02)*
+
+From 30.02, you can set the following values for container runtime:
+
+* containerd
+* crio
+* docker
+
+Example request schema showing *cri* is replaced with *containerRuntime*:
+
 [source,json]
 ----
-"containerRuntime": 
 {
-    "$ref": "#/components/schemas/common.ContainerRuntime"
-},
-
-"common.ContainerRuntime": 
-{
-    "description": "Represents the supported container runtime types",
-    "enum": [
-                [
-                    "docker",
-                    "containerd",
-                    "crio"
-                ]
-            ],
-
-    "type": "string"
+    "consoleAddr":"171.23.0.1",
+    "namespace":"twistlock",
+    "orchestration":"kubernetes",
+    "selinux":false,
+    "containerRuntime":"containerd",
+    "privileged":false,
+    "serviceAccounts":true,
+    "istio":false,
+    "collectPodLabels":false,
+    "proxy":null,
+    "taskName":null,
+    "gkeAutopilot":false
 }
----- 
+----
 
 IMPORTANT: You must update existing scripts that use either of the two endpoints when you upgrade to 30.02 or a future release.
 


### PR DESCRIPTION
Backward compatibility is misunderstood and also used with v1 endpoints.

Removing the sentence to avoid confusion.

