### PR TITLE
[Template] Show how to use the scale attribute

### DIFF
--- a/template/welcome/releases.adoc
+++ b/template/welcome/releases.adoc
@@ -7,7 +7,8 @@ We recommend that you upgrade to new major releases as they become available.
 
 The bell icon in Console automatically notifies you when new releases are available:
 
-image::update_bell.png[width=800]
+// Use the scale attribute to resize the image to 50% of its original size.
+image::update_bell.png[scale=50]
 
 
 [.task]
@@ -27,4 +28,4 @@ We are currently working on fixing all accounts that have this issue.
 . From the drop-down list, select *Prisma Cloud Compute Edition*.
 All releases available for download are displayed.
 +
-image::releases_csp.png[width=800]
+image::releases_csp.png[scale=30]


### PR DESCRIPTION
Use the scale attribute to resize images. You can also use the width and height attributes to scale images, but DocOps recommends setting scale to 60 for the best results across mediums (PDF and HTML).

