### PR TITLE
Update define-prisma-cloud-enterprise-settings.adoc

### DIFF
--- a/cspm/admin-guide/manage-prisma-cloud-administrators/define-prisma-cloud-enterprise-settings.adoc
+++ b/cspm/admin-guide/manage-prisma-cloud-administrators/define-prisma-cloud-enterprise-settings.adoc
@@ -46,7 +46,7 @@ image::auto-enable-default-policies.png[scale=30]
 
 [NOTE]
 ====
-If you enable policies of a specific severity, when you then clear the checkbox, the policies that were enabled previously are not disabled; going forward, policies that match the severity you cleared are no longer enabled to scan your cloud resources and generate alerts. If you want to disable the policies that are currently active, you must disable the status of each policy on the *Policies* page.
+If you enable policies of a specific severity, when you then clear the checkbox, the policies that were enabled previously are not disabled; going forward, policies that match the severity you cleared are no longer auto-enabled to scan your cloud resources and generate alerts. If you want to disable the policies that are currently active, you must disable the status of each policy on the *Policies* page.
 ====
 
 image::enterprise-settings-policies-disable.png[scale=30]

--- a/cspm/admin-guide/manage-prisma-cloud-administrators/define-prisma-cloud-enterprise-settings.adoc
+++ b/cspm/admin-guide/manage-prisma-cloud-administrators/define-prisma-cloud-enterprise-settings.adoc
@@ -46,7 +46,7 @@ image::auto-enable-default-policies.png[scale=30]
 
 [NOTE]
 ====
-If you enable policies of a specific severity, when you then clear the checkbox, the policies that were enabled previously are not disabled; going forward, policies that match the severity you cleared are no longer auto-enabled to scan your cloud resources and generate alerts. If you want to disable the policies that are currently active, you must disable the status of each policy on the *Policies* page.
+If you enable policies of a specific severity, when you then clear the checkbox, the policies that were enabled previously are not disabled; going forward, policies that match the severity you cleared are no longer automatically enabled to scan your cloud resources and generate alerts. If you want to disable the policies that are currently active, you must disable the status of each policy on the *Policies* page.
 ====
 
 image::enterprise-settings-policies-disable.png[scale=30]


### PR DESCRIPTION
Customer is getting confused on the wording used and mentioned that the edited sentence sounds contradictory to the previous one. Using "auto-enabled" clears up the confusion, in my opinion.

