### PR TITLE
Update deployment_app_embedded.adoc

### DIFF
--- a/compute/admin_guide/waas/deploy_waas/deploy_oob_hosts.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deploy_oob_hosts.adoc
@@ -10,7 +10,7 @@ Out-Of-Band for hosts is not supported for Windows.
 * A TLS certificate in PEM format.
 
 [.task]
-=== Create a WAAS rule for Out-Of-Band network traffic
+=== Create a WAAS Rule for Out-Of-Band Network Traffic
 
 To deploy WAAS for Out-Of-Band network traffic, create a new rule, define application endpoints, and select protections.
 
@@ -21,7 +21,7 @@ To deploy WAAS for Out-Of-Band network traffic, create a new rule, define applic
 include::fragments/create-waas-rule.adoc[leveloffset=0]
 
 [.task]
-=== Add an App (policy) to the rule
+=== Add an App (policy) to the Rule
 
 [.procedure]
 :waas_oob:

--- a/compute/admin_guide/waas/deploy_waas/deployment_app_embedded.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deployment_app_embedded.adoc
@@ -13,14 +13,14 @@ To disable WAAS protection, disable the WAAS rule, and re-expose the application
 To embed App-Embedded WAAS into your container or Fargate task:
 
 [.task]
-=== Create a rule for App-Embedded
+=== Create a Rule for App-Embedded
 
 [.procedure]
 . Open Console, and go to *Defend > WAAS > App-Embedded*.
 +
 image::waas_deployment_types_app_embedded.png[width=400]
 
-. Click *Add rule*.
+. Select *Add rule*.
 
 . Enter a *Rule name* and *Notes* (Optional) for describing the rule.
 
@@ -41,8 +41,7 @@ Defender reports a list of the endpoints and their resource path in *Compute > M
 
 === Add an App (policy) to the rule
 
-Comment: the following section should be modified, removing any reference to 'auto detect ports', as this is not available. Additionally, it'll be good to remove the comment about Linux/Windows hosts, as they are out of context here
-
+:waas-app-embedded:
 :waas_port:
 :response_headers:
 :advanced_tls:

--- a/compute/admin_guide/waas/deploy_waas/deployment_app_embedded.adoc
+++ b/compute/admin_guide/waas/deploy_waas/deployment_app_embedded.adoc
@@ -41,6 +41,8 @@ Defender reports a list of the endpoints and their resource path in *Compute > M
 
 === Add an App (policy) to the rule
 
+Comment: the following section should be modified, removing any reference to 'auto detect ports', as this is not available. Additionally, it'll be good to remove the comment about Linux/Windows hosts, as they are out of context here
+
 :waas_port:
 :response_headers:
 :advanced_tls:

--- a/compute/admin_guide/waas/deploy_waas/fragments/add-app-policy.adoc
+++ b/compute/admin_guide/waas/deploy_waas/fragments/add-app-policy.adoc
@@ -1,6 +1,6 @@
 . Select a WAAS rule to add an App in.
 
-. Click *Add app*.
+. Select *Add app*.
 
 . In the *App Definition* tab, enter an *App ID*.
 +
@@ -9,12 +9,10 @@ NOTE: The combination of *Rule name* and *App ID* must be unique across In-Line 
 If you have a Swagger or OpenAPI file, click *Import*, and select the file to load.
 +
 If you do not have a Swagger or OpenAPI file, manually define each endpoint by specifying the host, port, and path.
-+
-image::cwp-42473-add-app-policy.png[scale=10]
 
 .. In *Endpoint Setup*, click *Add Endpoint*.
-
-.. Specify endpoint in your web application that should be protected. Each defined application can have multiple protected endpoints.
++
+Specify endpoint in your web application that should be protected. Each defined application can have multiple protected endpoints.
 
 .. Enter *HTTP host* (optional, wildcards supported).
 +
@@ -22,10 +20,13 @@ HTTP hostnames are specified in the form of [hostname]:[external port].
 +
 The external port is defined as the TCP port on the host, listening for inbound HTTP traffic. If the value of the external port is "80" for non-TLS endpoints or "443" for TLS endpoints it can be omitted. Examples: "*.example.site", "docs.example.site", "www.example.site:8080", etc.
 
-.. Enter *App ports* as the internal port your app listens on (optional, if you selected *Automatically detect ports* while creating the rule). 
+.. Enter *App ports* as the internal port your app listens on.
+ifndef::waas-app-embedded[]
++
+(You can skip to enter App ports, if you selected *Automatically detect ports* while creating the rule). 
 +
 When *Automatically detect ports* is selected, any ports specified in a protected endpoint definition will be appended to the list of protected ports.
-+
+endif::waas-app-embedded[]
 Specify the TCP port listening for inbound HTTP traffic.
 +
 NOTE: If your application uses *TLS* or *gRPC*, you must specify a port number.
@@ -39,9 +40,11 @@ ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas_advanced_settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
 +
 image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+endif::waas_port[]
+ifdef::waas_hosts[]
 +
 NOTE: Protecting Linux-based hosts does not require specifying a *`WAAS port`* since WAAS listens on the same port as the protected application. Because Windows has its own internal traffic routing mechanisms, WAAS and the protected application cannot use the same *`App port`*. Consequently, when protecting Windows-based hosts the *`WAAS port`* should be set to the port end-users send requests to, and the *`App port`* should be set to a *different* port on which the protected application will listen and to which WAAS will forward traffic.
-endif::waas_port[]
+endif::waas_hosts[]
 
 .. If your application uses TLS, set *TLS* to *On*.
 +
@@ -115,8 +118,8 @@ endif::advanced_tls[]
 . The *Rule Overview* page shows all the WAAS rules created.
 +
 Select a rule to display the *Rule Resources*, and for each application a list of protected endpoints and the protections enabled for each endpoint are displayed.
-+
-image::waas_out_of_band_rule_overview.png[scale=20]
+//+
+//image::waas_out_of_band_rule_overview.png[scale=20]
 
 . Test protected endpoint using the following xref:../waas_app_firewall.adoc#sanity_tests[sanity tests].
 

--- a/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
+++ b/compute/admin_guide/waas/deploy_waas/fragments/create-waas-rule.adoc
@@ -5,7 +5,7 @@ endif::waas_oob[]
 ifdef::waas_oob[]
 . Open Console, and go to *Defend > WAAS > {Container|Host} > Out-of-Band*.
 endif::waas_oob[]
-. Click *Add rule*.
+. Select *Add rule*.
 
 .. Enter a *Rule Name*
 
@@ -53,7 +53,7 @@ endif::waas_oob_containers[]
 When enabled, the Defender inspects the API traffic to and from the protected API.
 Defender reports a list of the endpoints and their resource path in *Compute > Monitor > WAAS > API discovery*.
 
-. (Optional) Enable *Automatically detect ports* for an endpoint to deploy the WAAS's protection on ports identified in the unprotected web apps report in *Monitor > WAAS > Unprotected web apps* for each of the workloads in the rule scope.
+. (Optional) Enable *Automatically detect ports* for an endpoint to deploy WAAS protection on ports identified in the unprotected web apps report in *Monitor > WAAS > Unprotected web apps* for each of the workloads in the rule scope.
 +
 [NOTE]
 ====


### PR DESCRIPTION
I'd like to propose some changes to the WAAS app-embedded doc, given the particular nature of the policies. We need to clarify that the auto-detect option is not available. There are 2 different/conflicting screenshots here. Also, we should remove the Host (Linux/Win) comments

