### PR TITLE
Update security_assurance_policy.adoc

### DIFF
--- a/compute/admin_guide/welcome/security_assurance_policy.adoc
+++ b/compute/admin_guide/welcome/security_assurance_policy.adoc
@@ -68,7 +68,7 @@ Security releases happens anytime a new vulnerability that meets the criteria ou
 
 *Where do you take information on severity and fix details when triaging?*
 
-Console and Defender images are based on Red Hat Universal Base Images. 
+Console and Defender images are based on Red Hat Universal Base Images (ubi8/ubi-minimal). 
 For known vulnerabilities that are assigned a https://www.cve.org/About/Overview[CVE identifier], we rely on severity ratings and fixes released by Red Hat. 
 For zero-days or undocumented vulnerabilities (such as PRISMA-IDs), we rely on severity determined by our researchers.
 


### PR DESCRIPTION
Added the base image type that Console and Defender images are based on.

