### PR TITLE
Update add-checkov.adoc

### DIFF
--- a/code-security/admin_guide/get-started/connect-your-repositories/add-checkov.adoc
+++ b/code-security/admin_guide/get-started/connect-your-repositories/add-checkov.adoc
@@ -10,7 +10,7 @@ As a prerequisite, ensure Prisma Cloud IP addresses are on the allow list for Co
 
 [.procedure]
 
-. Install Checkov using CLI that Prima Cloud console provides.
+. Install Checkov using CLI that Prisma Cloud console provides.
 
 .. Select *Settings > Repositories > Add repository* and then select *Checkov*.
 +


### PR DESCRIPTION
Was reading to learn about Prisma Checkov, and noticed a typo "prima", corrected to "prisma"

