### PR TITLE
Fix wrong argument on CKV_AZURE_139 policy

### DIFF
--- a/code-security/policy-reference/azure-policies/azure-networking-policies/ensure-azure-acr-is-set-to-disable-public-networking.adoc
+++ b/code-security/policy-reference/azure-policies/azure-networking-policies/ensure-azure-acr-is-set-to-disable-public-networking.adoc
@@ -30,7 +30,7 @@
 === Description 
 
 
-Disabling the public network access improves security by ensuring your Azure ACRs.
+Disabling public network access improves security for your Azure Container Registry (ACRs).
 
 === Fix - Buildtime
 
@@ -48,7 +48,7 @@ resource "azurerm_container_registry" "ckv_unittest_pass" {
   name                          = "containerRegistry1"
   resource_group_name           = azurerm_resource_group.rg.name
   location                      = azurerm_resource_group.rg.location
-  + public_network_access_enabled = false
+  public_network_access_enabled = false
 }
 ----
 

--- a/code-security/policy-reference/azure-policies/azure-networking-policies/ensure-azure-acr-is-set-to-disable-public-networking.adoc
+++ b/code-security/policy-reference/azure-policies/azure-networking-policies/ensure-azure-acr-is-set-to-disable-public-networking.adoc
@@ -30,7 +30,7 @@
 === Description 
 
 
-Disabling the public network access by disabling automated anonymous pulling improves security by ensuring your Azure ACRs.
+Disabling the public network access improves security by ensuring your Azure ACRs.
 
 === Fix - Buildtime
 
@@ -39,7 +39,7 @@ Disabling the public network access by disabling automated anonymous pulling imp
 
 
 * *Resource:* azurerm_container_registry
-* *Arguments:* anonymous_pull_enabled
+* *Arguments:* public_network_access_enabled
 
 
 [source,go]
@@ -48,7 +48,7 @@ resource "azurerm_container_registry" "ckv_unittest_pass" {
   name                          = "containerRegistry1"
   resource_group_name           = azurerm_resource_group.rg.name
   location                      = azurerm_resource_group.rg.location
-  public_network_access_enabled = false
+  + public_network_access_enabled = false
 }
 ----
 


### PR DESCRIPTION
It seems that the argument specified on the guideline is wrong.
I took advantage to improve the description of the fix.