### PR TITLE
Update flow-logs-compression.adoc

### DIFF
--- a/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-gcp/flow-logs-compression.adoc
+++ b/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-gcp/flow-logs-compression.adoc
@@ -9,6 +9,11 @@ Prisma Cloud recommends that you enable flow logs compression. This additional a
 
 When you enable Dataflow compression on Prisma Cloud, the Dataflow pipeline resources are created in the same GCP project associated with the Google Cloud Storage bucket to which your VPC Flow logs are sent, and it saves the compressed logs also to the Cloud Storage bucket. Therefore, if you are onboarding a GCP Organization and enabling Dataflow compression to it or enabling Dataflow compression to an existing GCP Organization that has been added to Prisma cloud, make sure that the Dataflow-enabled Project ID is the same Google Cloud Storage bucket to which you send VPC flow logs.
 
+[NOTE]
+====
+If the prisma cloud service user, that is resposible for the organisation, is created in a GCP project, that is different from the project where the storage bucket for flow logs resides, the Dataflow API should be enabled on both projects so that dataflow compression can be triggered. 
+====
+
 In order to launch the Dataflow job and create and stage the compressed files, the following permissions are required:
 
 * Enable the _dataflow.googleapi.com_ Dataflow API.

--- a/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-gcp/flow-logs-compression.adoc
+++ b/cspm/admin-guide/connect-your-cloud-platform-to-prisma-cloud/onboard-gcp/flow-logs-compression.adoc
@@ -11,7 +11,7 @@ When you enable Dataflow compression on Prisma Cloud, the Dataflow pipeline reso
 
 [NOTE]
 ====
-If the prisma cloud service user, that is resposible for the organisation, is created in a GCP project, that is different from the project where the storage bucket for flow logs resides, the Dataflow API should be enabled on both projects so that dataflow compression can be triggered. 
+If the Prisma Cloud service user responsible for the organization is created in a GCP project that is different from the project where the storage bucket for flow logs resides, the Dataflow API should be enabled on both projects so that dataflow compression can be triggered. 
 ====
 
 In order to launch the Dataflow job and create and stage the compressed files, the following permissions are required:


### PR DESCRIPTION
gcp flow log and the flow log compression doesn't work, if the service user and the storage bucket don't reside on the same project, unless dataflow api is enabled on both

