### PR TITLE
[Compute AG: App-Embedded Defender]: Fragments + App-Embedded in GCR

### DIFF
--- a/compute/admin_guide/book_compute_edition.yml
+++ b/compute/admin_guide/book_compute_edition.yml
@@ -144,6 +144,8 @@ topics:
             file: install_app_embedded_defender_fargate.adoc
           - name: Deploy App-Embedded Defender in ACI
             file: deploy-app-embedded-defender-aci.adoc
+          - name: Deploy App-Embedded Defender in GCR
+            file: deploy-app-embedded-defender-gcr.adoc
           - name: Default Setting for App-Embedded Defender File System Monitoring
             file: config_app_embedded_fs_mon.adoc
           - name: Default Setting for App-Embedded Defender File System Protection

--- a/compute/admin_guide/book_prisma_cloud.yml
+++ b/compute/admin_guide/book_prisma_cloud.yml
@@ -123,6 +123,8 @@ topics:
             file: install_app_embedded_defender_fargate.adoc
           - name: Deploy App-Embedded Defender in ACI
             file: deploy-app-embedded-defender-aci.adoc
+          - name: Deploy App-Embedded Defender in GCR
+            file: deploy-app-embedded-defender-gcr.adoc
           - name: Default Setting for App-Embedded Defender File System Monitoring
             file: config_app_embedded_fs_mon.adoc
           - name: Default Setting for App-Embedded Defender File System Protection

--- a/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-aci.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-aci.adoc
@@ -1,5 +1,8 @@
 :toc: macro
+
 == Deploy App-Embedded Defender in Azure Container Instance (ACI)
+
+toc::[]
 
 Deploy an App-Embedded Defender in ACI to provide runtime protection to App-Embedded applications installed in ACI.
 The App-Embedded Defender enforces runtime policy on the application entrypoint and any child processes created by this entrypoint.
@@ -21,12 +24,7 @@ To learn more about App-Embedded Defender's capabilities, see:
 
 === Configure App-Embedded Defender in Prisma Console UI
 
-Prisma Console provides you with an App-Embedded Defender bundle that contains the Dockerfile with App-Embedded configurations and the Defender installation binary file.
-
-You can select one of the *Deployment types*: Dockerfile or Manual.
-
-* *Dockerfile*: Creates a new Dockerfile based on your Dockerfile and embeds the App-Embedded parameters.
-* *Manual*: Select the manual method to customize the required Dockerfile parameters in the Console UI and directly download the App-Embedded Defender binary file.
+include::fragments/configure-app-embedded-defender-in-prisma.adoc[leveloffset=0]
 
 *Prerequisites*
 
@@ -40,73 +38,11 @@ You can select one of the *Deployment types*: Dockerfile or Manual.
 Upload your Dockerfile and Prisma Cloud creates a new Dockerfile with App-Embedded Defender parameters and the Defender binary file.
 
 [.procedure]
-
-. Log in to Prisma Cloud Console.
-
-. Go to *Manage > Defenders > Deployed Defenders > Manual deploy*.
-+
-image::deploy-app-embedded-defender-aci.gif[scale=20]
-
-. In Deployment method, select *Single Defender*.
-
-. Select the Defender type as *Container Defender - App-Embedded*.
-
-. Select the DNS name (configured in *Manage > Defenders > Names (SAN)* or public IP address that Defender will use to connect to Prisma Console.
-
-. *Enable file system runtime protection* to allow the sensors to monitor file system events regardless of how your runtime policy is configured, and could impact the underlying workload's performance.
-
-. Select Deployment type as *Dockerfile*.
-.. In *App ID*, enter a unique identifier for the App-Embedded Defender.
-All vulnerability, compliance, and runtime findings for the container will be aggregated under this App ID. In Console, the App ID is presented as the image name. Be sure to specify an App ID that lets you easily trace findings back to the image.
-.. In *Data folder*, enter the path that the Defender will use to write files and store information.
-.. *Dockerfile*: Upload the Dockerfile for your container image.
-Set up the task's entrypoint in the Dockerfile. The embed process modifies the container's entrypoint to run the App-Embedded Defender first, which in turn starts the original entrypoint process. The Defender starts defending the app from the entrypoint and the thread/child process created by this entrypoint.
-
-. *Download* the App-embedded bundle that contains the Dockerfile with Defender deployment configurations appended to your Dockerfile and the App-Embedded Defender binary file.
-
+include::fragments/embed-app-embedded-defender-with-dockerfile.adoc[leveloffet=0]
 . Rebuild the image and embed the Defender in ACI.
 
-[.task]
-==== Embed App-Embedded Defender Manually
-
-Embed App-Embedded Defender into a container image manually. Modify your Dockerfile with the given configurations, download the App-Embedded Defender binaries into the image's build context, then rebuild the image.
-
-*Prerequisites*
-
-* At runtime, the container where you're embedding App-Embedded Defender can reach Console over the network. For Enterprise Edition, Defender talks to Console on port 443. For Compute Edition, Defender talks to Console on port 8084.
-* The host where you are rebuilding your container image with App-Embedded Defender can reach Console over the network on port 8083.
-* You have the Dockerfile for your image.
-
-[.procedure]
-. Log in to Prisma Cloud Console.
-. Go to *Manage > Defenders > Deployed Defenders > Manual deploy*.
-. In Deployment method, select *Single Defender*.
-. Select the Defender type as *Container Defender - App-Embedded*.
-. Select the DNS name (configured in *Manage > Defenders > Names (SAN)* or public IP address that Defender will use to connect to Prisma Console.
-. *Enable file system runtime protection* to allow the sensors to monitor file system events regardless of how your runtime policy is configured, and could impact the underlying workload's performance.
-. Select *Deployment type* as *Manual*
-+
-Follow the instructions for embedding App-Embedded Defender into your image.
-
-.. Download the App-Embedded bundle using the command or download the file directly.
-.. Configure your Dockerfile and set the following environment variables:
-  
-  DEFENDER_TYPE="appEmbedded"
-  ENV DEFENDER_APP_ID="Unique identifier for the App-Embedded Defender in Prisma Cloud Console"
-  FILESYSTEM_MONITORING="true/false"
-  WS_ADDRESS="Websocket address the Defender is communicating to"
-  DATA_FOLDER="The path that Defender uses to store its metadata"
-  INSTALL_BUNDLE="The access key for the Prisma Console, copy this from the Console"
-  FIPS_ENABLED="true/false"
-  ENTRYPOINT="Modify the entrypoint for the app to start the app under the control of App-Embedded Defender"
-
-.. Add the App-Embedded Defender to Dockerfile.
-  
-  ADD twistlock_defender_app_embedded.tar.gz <DATA_FOLDER>
-
-.. Modify the entrypoint so that your app starts under the control of App-Embedded Defender.
-
-.. Rebuild your image and embed the Defender in ACI.
+//==== Embed App-Embedded Defender Manually
+include::fragments/embed-app-embedded-defender-manually.adoc[leveloffset=0]
 
 [.task]
 === Embed App-Embedded Defender in Azure ACI
@@ -151,153 +87,20 @@ If your Dockerfile is in the current directory, use *.* for <local_path_host-Doc
 
 . In Azure Container instances, verify that your application shows a *running* status.
 
-[.task]
-=== Embed App-Embedded Defender with twistcli
+//=== Embed App-Embedded Defender with twistcli
 
-Use the `twistcli` command line tool to embed an App-Embedded Defender in ACI.
+:app-embedded-defender-aci:
+include::fragments/embed-app-embedded-defender-twistcli.adoc[leveloffset=0]
 
-*Prerequisites*:
-
-* Running tasks can connect to Prisma Cloud Console over the network.
-* Prisma Cloud Defender connects to Console to retrieve runtime policies and send audits.
-ifdef::prisma_cloud[]
-* Defender uses port 443 to connect to the Prisma Cloud Console.
-endif::prisma_cloud[]
-ifdef::compute_edition[]
-* Defender uses port 8084 to connect to the Prisma Cloud Console by default.
-You can configure the port number when you install the Prisma Cloud Console.
-endif::compute_edition[]
-* The container where you're embedding App-Embedded Defender can reach Console's port 8084 over the network.
-* You have Dockerfile for you image.
-* Azure CLI.
-
-[.procedure]
-. Log into Prisma Cloud Console.
-. Download `twistcli`
-ifdef::prisma_cloud[]
-.. Go to *Compute > Manage > System > Utilities*, and download `twistcli` for your platform.
-endif::prisma_cloud[]
-ifdef::compute_edition[]
-.. Go to *Manage > System > Utilities*, and download `twistcli` for your platform.
-endif::compute_edition[]
-
-. Run `twistcli` to embed Defender in Azure.
-+
-A file named _app_embedded_embed_<app_id>.zip_ is created, that has the Dockerfile for App-Embedded Defender and App-Embedded Defender binary file.
-ifdef::compute_edition[]
-
-  $ ./twistcli app-embedded embed \
-     --user <USER> \
-     --password <PASSWORD> \
-     --address "<CONSOLE_URL>" \
-     --app-id <APP-ID name> \
-     --data-folder /tmp \
-     <Docker-file-path-location>
-endif::compute_edition[]
-ifdef::prisma_cloud[]
-+
-Get the API *Token details* from *Manage > System > Utilities > API token, Token details*.
-
-  $ ./twistcli app-embedded embed \
-    --user <USER> \
-    --password <PASSWORD> \
-    --token=$token \
-    --address "<CONSOLE_URL>" \
-    --app-id <APP-ID name> \
-    --data-folder /tmp \
-    <path-to-Dockerfile>
-endif::prisma_cloud[]
-+
-* <user> -- Name of a Prisma Cloud user with a minimum xref:../../../authentication/user_roles.adoc[role] of Defender Manager.
-+
-* <password> -- For Prisma Cloud Enterprise Edition, you can also specify the secret key that you configured under *Prisma > Settings > Access Control > Access Keys*.
-+
-* <token> -- API Token for authenticating with Prisma Cloud Console. (For Enterprise Edition only)
-+
-* <CONSOLE> -- DNS name or IP address for Console.
-+
-* <APP-ID> -- Unique identifier.
-+
-When setting `<APP-ID>`, specify a value that lets you easily trace findings back to the image. All vulnerability, compliance, and runtime findings for the container will be aggregated under this App ID.
-+
-In Console, the App ID is presented as the image name.
-+
-* <DATA-FOLDER> -- Readable and writable directory in the container's filesystem.
-+
-* To enable file system protection, add the `--filesystem-monitoring` flag to the `twistcli` command.
-
-. Unpack _app_embedded_embed_help.zip_.
-
-. Create and push the docker image to ACR.
-.. az login
-.. docker login <Azure-ID> -u <Azure_username> -p <Access_key_password>
-.. docker build -t <Azure-ID>/REPO:TAG <DockerfileTwistlock_Destination_file>
-.. Verify the image built
-	docker images
-.. docker push <Registry>/REPO:TAG
-.. Check the image exists in Azure repo
- 
-  $ az acr repository show-tags \
-  --name <registry> \
-  --repository <repository> \
-  --top 10 \
-  --orderby time_desc \
-  --detail
-
-.. Create a container instance (ACI)
-
-  $ az container create -g <MyResourceGroup> \
-  --name <APP-EMBEDDED_NAME>  \
-  --image <myAcrRegistry.azurecr.io/myimage:latest> \
-  --registry-username <username> \
-  --registry-password <password> \
-  --location "East US" \
-  --ip-address Public \
-  --os-type Linux \
-  --ports 8080 \
-  --cpu 1 \
-  --memory 1.5
-
-#### Delete a container instance
+#### Delete a Container Instance
 
   $ az container delete -g <MyContainerGroup> --name <Container-name> -y
 
 === View Deployed Defenders
 
-ifdef::prisma_cloud[]
-You can review the list of all Defenders connected to Console under *Compute > Manage > Defenders > Deployed Defenders*.
-endif::prisma_cloud[]
+include::fragments/view-deployed-defenders.adoc[leveloffset=0]
 
-ifdef::compute_edition[]
-You can review the list of all Defenders connected to Console under *Manage > Defenders > Deployed Defenders*.
-endif::compute_edition[]
-
-To narrow the list to just App-Embedded Defenders, filter the table by type `Type: Container Defender - App-Embedded`.
-
-image::connected_app_embedded_defenders.png[scale=40]
-
-By default, Prisma Cloud removes disconnected App-Embedded Defenders from the list after an hour.
-As part of the cleanup process, data collected by the disconnected Defender is also removed from *Monitor > Runtime > App-Embedded observations*.
-
-ifdef::prisma_cloud[]
-[NOTE]
-====
-There is an advanced settings dialog under *Compute > Manage > Defenders > Deployed Defenders*, which lets you configure how long Prisma Cloud should wait before cleaning up disconnected Defenders.
-This setting doesn't apply to App-Embedded Defenders.
-Disconnected App-Embedded Defenders are always removed after one hour.
-====
-endif::prisma_cloud[]
-
-ifdef::compute_edition[]
-[NOTE]
-====
-There is an advanced settings dialog under *Manage > Defenders > Deployed Defenders*, which lets you configure how long Prisma Cloud should wait before cleaning up disconnected Defenders.
-This setting doesn't apply to App-Embedded Defenders.
-Disconnected App-Embedded Defenders are always removed after one hour.
-====
-endif::compute_edition[]
-
-=== Trigger Events for App-embedded
+=== Trigger Events for App-Embedded
 
 Refer to xref:../../../runtime_defense/runtime_defense_app_embedded.adoc[Runtime defense for App-Embedded].
 

--- a/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-aci.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-aci.adoc
@@ -86,6 +86,8 @@ If your Dockerfile is in the current directory, use *.* for <local_path_host-Doc
 .. Select *Create*.
 
 . In Azure Container instances, verify that your application shows a *running* status.
++
+This App-Embedded Defender running in ACI is now recognized in Prisma Console under *Manage > Defenders > Deployed Defenders*.
 
 //=== Embed App-Embedded Defender with twistcli
 

--- a/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-gcr.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-gcr.adoc
@@ -1,0 +1,132 @@
+:toc: macro
+
+== Deploy App-Embedded Defender in Google Cloud Run (GCR)
+
+toc::[]
+
+Deploy an App-Embedded Defender in GCR to provide runtime protection to App-Embedded applications installed in GCR.
+
+The App-Embedded Defender enforces runtime policy on the application entrypoint and any child processes created by this entrypoint.
+To learn when to use App-Embedded Defenders, see xref:../defender_types.adoc[Defender types].
+
+To learn more about App-Embedded Defender's capabilities, see:
+
+* xref:../../../vulnerability_management/app_embedded_scanning.adoc[Vulnerability scanning for App-Embedded]
+* xref:../../../compliance/app_embedded_scanning.adoc[Compliance scanning for App-Embedded]
+* xref:../../../runtime_defense/runtime_defense_app_embedded.adoc[Runtime defense for App-Embedded]
+* Protecting front-end containers at runtime with xref:../../../waas/waas.adoc[WAAS]
+
+=== System Requirements
+
+* GCR supports Linux (X86) containers
+* TBD
+
+=== Prerequisites
+
+* You can connect to GCR and DockerHub.
+
+*Configure GCP to authenticate Prisma Cloud*
+
+* Sign in to your Google Cloud account.
+* Log in to Google Cloud Registry.
+* In the Google Cloud Console, on the project selector page, select or create a Google Cloud project.
+* Set "private" visibility for your GCP container registry host under *GCP project > Home > Container Registry > Settings*.
+* Configure GCloud authentication using any of the following options:
+
+** Authenticate using GCP user credentials:
+
+  $ gcloud auth login ### Type the User GCP credentials
+  $ cat ~/.docker/config.json  ### Check that GCP has GCLOUD users configured
+
+** Authenticate using GCP Service Account:
+
+  $ gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE ###KEY-FILE is the Service Account key file under *GCP > Services Accounts > Actions > Manage keys*
+
+*Configure Docker for GCP in your localhost*
+
+  $ gcloud auth configure-docker
+  $ cat ~/.docker/config.json.  ### check that GCP has GCLOUD users configured
+
+=== Configure App-Embedded Defender in Prisma Console UI
+
+include::fragments/configure-app-embedded-defender-in-prisma.adoc[leveloffset=0]
+
+[.task]
+==== Embed App-Embedded Defender with Dockerfile
+
+Upload your Dockerfile and Prisma Cloud creates a new Dockerfile with App-Embedded Defender parameters and the Defender binary file.
+
+[.procedure]
+include::fragments/embed-app-embedded-defender-with-dockerfile.adoc[leveloffet=0]
+. Rebuild the image and embed the Defender in GCR.
+
+//==== Embed App-Embedded Defender Manually
+include::fragments/embed-app-embedded-defender-manually.adoc[leveloffset=0]
+
+[.task]
+=== Embed App-Embedded Defender in GCR
+
+Prisma Cloud uses the updated Dockerfile to deploy the Defender in your containers running in GCR. 
+Use the updated Dockerfile to build the image for App-Embedded Defender, push it to Google Container Registry, and then run the Google Container instance.
+
+*Prerequisite*:
+
+* Create a new https://cloud.google.com/artifact-registry/docs/repositories/create-repos[GCR repository], if not already exists.
+
+[.procedure]
+
+. Log in to Docker
+
+  docker login
+
+. Copy the App-Embedded zipped bundle and unzip it to get the Dockerfile and App-Embedded Defender binary.
+
+. Build the Dockerfile:
+
+  docker build -t <GCP_Container_Registry>:<docker_images_name>  <local_path_host_dockerfile>
++
+If your Dockerfile is in the current directory, use *.* for <local_path_host-Dockerfile>
+
+. *Push the docker image to GCR*:
+
+  docker push HOSTNAME/PROJECT-ID/IMAGE:TAG
+
+.. Verify the docker image exists in your *GCP project > Container Registry > Images* under your relevant repository.
+
+. *Deploy Docker image in Google Cloud Run using Google Console*:
+
+.. Select your *Container Registry > Images*, and select *Actions > Deploy to Cloud Run*.
+.. Enter a *Service name* or select the default value.
+.. Set the *CPU allocation and pricing* to *CPU is always allocated*.
+.. Select the *Ingress* traffic to allow *All* requests, including requests directly from the internet to the *run*.
+
+. In the *Container, Networking, Security* section, enter the *Container port* as 8080.
+
+. Select *CREATE*.
+
+. Go to *Cloud Run* and verify the Docker Container service running in GCP.
++
+This App-Embedded Defender running in GCR is now recognized in Prisma Console under *Manage > Defenders > Deployed Defenders*.
+
+//=== Embed App-Embedded Defender with twistcli
+:app-embedded-defender-gcr:
+include::fragments/embed-app-embedded-defender-twistcli.adoc[]
+
+#### Delete a Container Instance
+
+  $ az container delete -g <MyContainerGroup> --name <Container-name> -y
+
+=== Trigger Events for App-Embedded
+
+Refer to xref:../../../runtime_defense/runtime_defense_app_embedded.adoc[Runtime defense for App-Embedded].
+
+To trigger the App Server logs, get the GCP URL from GCP Docker Container service.
+
+  $ curl -k -X POST -H "Authorization: Bearer $(gcloud auth print-identity-token)" <app_emb_gcp_URL>/runsee -d $(echo 'ldd --help'|base64)
+
+=== Monitor App-Embedded Events
+
+You can view the xref:../../../runtime_defense/runtime_defense_app_embedded.adoc[App-Embedded runtime events] by app ID under *Monitor > Events > App-Embedded audits*, and view the xref:../../../runtime_defense/incident_explorer.adoc[App-Embedded incidents] under *Monitor > Runtime > Incident Explorer*.
+
+You can also xref:../../../waas/deploy_waas/deployment_app_embedded.adoc[deploy WAAS for Containers Protected By App-Embedded Defender], create a WAAS rule policy, add an app, enable protections, run WAAS sanity tests, and monitor the events under *Monitor > Events > WAAS for App-Embedded*.
+

--- a/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-gcr.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/deploy-app-embedded-defender-gcr.adoc
@@ -19,33 +19,35 @@ To learn more about App-Embedded Defender's capabilities, see:
 === System Requirements
 
 * GCR supports Linux (X86) containers
-* TBD
+* Any Docker image with Prisma Cloud App-Embedded Defender binary
+* Google Cloud Registry (recommended)
 
 === Prerequisites
 
-* You can connect to GCR and DockerHub.
+* You can connect to GCR and DockerHub
 
 *Configure GCP to authenticate Prisma Cloud*
 
 * Sign in to your Google Cloud account.
 * Log in to Google Cloud Registry.
 * In the Google Cloud Console, on the project selector page, select or create a Google Cloud project.
-* Set "private" visibility for your GCP container registry host under *GCP project > Home > Container Registry > Settings*.
+** Set "private" visibility for your GCP container registry host under *GCP project > Home > Container Registry > Settings*.
 * Configure GCloud authentication using any of the following options:
 
 ** Authenticate using GCP user credentials:
 
   $ gcloud auth login ### Type the User GCP credentials
-  $ cat ~/.docker/config.json  ### Check that GCP has GCLOUD users configured
+  $ cat ~/.docker/config.json  ### Check that GCP has gcloud users configured
 
 ** Authenticate using GCP Service Account:
 
-  $ gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE ###KEY-FILE is the Service Account key file under *GCP > Services Accounts > Actions > Manage keys*
+  $ gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE 
+  ### KEY-FILE is the Service Account key file under *GCP > Service Accounts > Actions > Manage keys*
 
 *Configure Docker for GCP in your localhost*
 
   $ gcloud auth configure-docker
-  $ cat ~/.docker/config.json.  ### check that GCP has GCLOUD users configured
+  $ cat ~/.docker/config.json.  ### check that GCP has gcloud users configured
 
 === Configure App-Embedded Defender in Prisma Console UI
 

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/configure-app-embedded-defender-in-prisma.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/configure-app-embedded-defender-in-prisma.adoc
@@ -1,0 +1,6 @@
+Prisma Console provides you with an App-Embedded Defender bundle that contains the Dockerfile with App-Embedded configurations and the Defender installation binary file.
+
+You can select one of the *Deployment types*: Dockerfile or Manual.
+
+* *Dockerfile*: Creates a new Dockerfile based on your Dockerfile and embeds the App-Embedded parameters.
+* *Manual*: Select the manual method to customize the required Dockerfile parameters in the Console UI and directly download the App-Embedded Defender binary file.

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-manually.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-manually.adoc
@@ -1,0 +1,41 @@
+[.task]
+==== Embed App-Embedded Defender Manually
+
+Embed App-Embedded Defender into a container image manually. Modify your Dockerfile with the given configurations, download the App-Embedded Defender binaries into the image's build context, then rebuild the image.
+
+*Prerequisites*
+
+* At runtime, the container where you're embedding App-Embedded Defender can reach Console over the network. For Enterprise Edition, Defender talks to Console on port 443. For Compute Edition, Defender talks to Console on port 8084.
+* The host where you are rebuilding your container image with App-Embedded Defender can reach Console over the network on port 8083.
+* You have the Dockerfile for your image.
+
+[.procedure]
+. Log in to Prisma Cloud Console.
+. Go to *Manage > Defenders > Deployed Defenders > Manual deploy*.
+. In Deployment method, select *Single Defender*.
+. Select the Defender type as *Container Defender - App-Embedded*.
+. Select the DNS name (configured in *Manage > Defenders > Names (SAN)* or public IP address that Defender will use to connect to Prisma Console.
+. *Enable file system runtime protection* to allow the sensors to monitor file system events regardless of how your runtime policy is configured, and could impact the underlying workload's performance.
+. Select *Deployment type* as *Manual*
++
+Follow the instructions for embedding App-Embedded Defender into your image.
+
+.. Download the App-Embedded bundle using the command or download the file directly.
+.. Configure your Dockerfile and set the following environment variables:
+  
+  DEFENDER_TYPE="appEmbedded"
+  ENV DEFENDER_APP_ID="Unique identifier for the App-Embedded Defender in Prisma Cloud Console"
+  FILESYSTEM_MONITORING="true/false"
+  WS_ADDRESS="Websocket address the Defender is communicating to"
+  DATA_FOLDER="The path that Defender uses to store its metadata"
+  INSTALL_BUNDLE="The access key for the Prisma Console, copy this from the Console"
+  FIPS_ENABLED="true/false"
+  ENTRYPOINT="Modify the entrypoint for the app to start the app under the control of App-Embedded Defender"
+
+.. Add the App-Embedded Defender to Dockerfile.
+  
+  ADD twistlock_defender_app_embedded.tar.gz <DATA_FOLDER>
+
+.. Modify the entrypoint so that your app starts under the control of App-Embedded Defender.
+
+.. Rebuild your image and embed the Defender in Cloud instance.

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
@@ -1,0 +1,124 @@
+[.task]
+=== Embed App-Embedded Defender with twistcli
+
+Use the `twistcli` command line tool to embed an App-Embedded Defender in ACI.
+
+*Prerequisites*:
+
+* Running tasks can connect to Prisma Cloud Console over the network.
+* Prisma Cloud Defender connects to Console to retrieve runtime policies and send audits.
+ifdef::prisma_cloud[]
+* Defender uses port 443 to connect to the Prisma Cloud Console.
+endif::prisma_cloud[]
+ifdef::compute_edition[]
+* Defender uses port 8084 to connect to the Prisma Cloud Console by default.
+You can configure the port number when you install the Prisma Cloud Console.
+endif::compute_edition[]
+* The container where you're embedding App-Embedded Defender can reach Console's port 8084 over the network.
+* You have Dockerfile for you image.
+* Azure CLI.
+
+[.procedure]
+. Log into Prisma Cloud Console.
+. Download `twistcli`
+ifdef::prisma_cloud[]
+.. Go to *Compute > Manage > System > Utilities*, and download `twistcli` for your platform.
+endif::prisma_cloud[]
+ifdef::compute_edition[]
+.. Go to *Manage > System > Utilities*, and download `twistcli` for your platform.
+endif::compute_edition[]
+
+. Run `twistcli` to embed Defender in Azure.
++
+A file named _app_embedded_embed_<app_id>.zip_ is created, that has the Dockerfile for App-Embedded Defender and App-Embedded Defender binary file.
+ifdef::compute_edition[]
+
+  $ ./twistcli app-embedded embed \
+     --user <USER> \
+     --password <PASSWORD> \
+     --address "<CONSOLE_URL>" \
+     --app-id <APP-ID name> \
+     --data-folder /tmp \
+     <Docker-file-path-location>
+endif::compute_edition[]
+ifdef::prisma_cloud[]
++
+Get the API *Token details* from *Manage > System > Utilities > API token, Token details*.
+
+  $ ./twistcli app-embedded embed \
+    --user <USER> \
+    --password <PASSWORD> \
+    --token=$token \
+    --address "<CONSOLE_URL>" \
+    --app-id <APP-ID name> \
+    --data-folder /tmp \
+    <path-to-Dockerfile>
+endif::prisma_cloud[]
++
+* <user> -- Name of a Prisma Cloud user with a minimum xref:../../../authentication/user_roles.adoc[role] of Defender Manager.
++
+* <password> -- For Prisma Cloud Enterprise Edition, you can also specify the secret key that you configured under *Prisma > Settings > Access Control > Access Keys*.
++
+* <token> -- API Token for authenticating with Prisma Cloud Console. (For Enterprise Edition only)
++
+* <CONSOLE> -- DNS name or IP address for Console.
++
+* <APP-ID> -- Unique identifier.
++
+When setting `<APP-ID>`, specify a value that lets you easily trace findings back to the image. All vulnerability, compliance, and runtime findings for the container will be aggregated under this App ID.
++
+In Console, the App ID is presented as the image name.
++
+* <DATA-FOLDER> -- Readable and writable directory in the container's filesystem.
++
+* To enable file system protection, add the `--filesystem-monitoring` flag to the `twistcli` command.
+
+. Unpack _app_embedded_embed_help.zip_.
+ifdef::app-embedded-defender-aci[]
+. Create and push the docker image to ACR.
+
+ $ az login
+ $ docker login <Azure-ID> -u <Azure_username> -p <Access_key_password>
+ $ docker build -t <Azure-ID>/REPO:TAG <DockerfileTwistlock_Destination_file> 
+ $ docker images
+ $ docker push <Registry>/REPO:TAG
+
+.. Check the image exists in Azure repo
+ 
+  $ az acr repository show-tags \
+  --name <registry> \
+  --repository <repository> \
+  --top 10 \
+  --orderby time_desc \
+  --detail
+
+.. Create a container instance (ACI)
+
+  $ az container create -g <MyResourceGroup> \
+  --name <APP-EMBEDDED_NAME>  \
+  --image <myAcrRegistry.azurecr.io/myimage:latest> \
+  --registry-username <username> \
+  --registry-password <password> \
+  --location "East US" \
+  --ip-address Public \
+  --os-type Linux \
+  --ports 8080 \
+  --cpu 1 \
+  --memory 1.5
+endif::app-embedded-defender-aci[]
+ifdef::app-embedded-defender-gcr[]
+. Create and push the docker image to GCR.
+.. steps
+.. steps
+.. Verify the image built
+	docker images
+.. docker push <Registry>/REPO:TAG
+
+.. Check the image exists in GCR repo
+
+.. Create a container intance in GCR
+ 
+  $ commands
+
+endif::app-embedded-defender-gcr[]
+

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
@@ -19,7 +19,7 @@ endif::compute_edition[]
 * Cloud CLI, such as Azure CLI, or Google Cloud CLI.
 
 [.procedure]
-. Log into Prisma Cloud Console.
+. Log in to Prisma Cloud Console.
 . Download `twistcli`
 ifdef::prisma_cloud[]
 .. Go to *Compute > Manage > System > Utilities*, and download `twistcli` for your platform.
@@ -99,7 +99,7 @@ ifdef::app-embedded-defender-aci[]
   --image <myAcrRegistry.azurecr.io/myimage:latest> \
   --registry-username <username> \
   --registry-password <password> \
-  --location "East US" \
+  --location <location> \
   --ip-address Public \
   --os-type Linux \
   --ports 8080 \
@@ -113,7 +113,7 @@ ifdef::app-embedded-defender-gcr[]
 
   $ gcloud auth login
 
-.. Or, Authenticate using GCP Service Account key (KEY-FILE): (Get the KEY-FILE from *GCP > Services Accounts > Actions > Manage keys*)
+.. Or, Authenticate using GCP Service Account key (KEY-FILE): (Get the KEY-FILE from *GCP > Service Accounts > Actions > Manage keys*)
   
   $ gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE
 
@@ -124,7 +124,7 @@ ifdef::app-embedded-defender-gcr[]
 .. Build the Dockerfile
 
    $ docker build -t <GCP_Container_Registry>:<docker_images_name>  <local_path_host_dockerfile>
-   $ docker images ###Verify the image built
+   $ docker images ### Verify the image built
 
 .. Push the image to GCR
 
@@ -136,10 +136,15 @@ ifdef::app-embedded-defender-gcr[]
  
   $ gcloud run deploy [SERVICE] \
   --image <IMAGE_URL> \
+  --service-account <SERVICE_ACCOUNT> \
+  --no-cpu-throttling \
   --platform managed \
   --ingress <all> \
-  --cpu <CPU is always allocated> \
-  --port 8080
+  --port <port-exposed-in-dockerfile> \
+  --region <REGION> \
+  --project <PROJECT_NAME>
++
+If there is no port exposed in Dockerfile, GCP Cloud Run will use 8080 port as the default.
 
 endif::app-embedded-defender-gcr[]
 

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-twistcli.adoc
@@ -1,7 +1,7 @@
 [.task]
 === Embed App-Embedded Defender with twistcli
 
-Use the `twistcli` command line tool to embed an App-Embedded Defender in ACI.
+Use the `twistcli` command line tool to embed an App-Embedded Defender in your Cloud Container Registries.
 
 *Prerequisites*:
 
@@ -16,7 +16,7 @@ You can configure the port number when you install the Prisma Cloud Console.
 endif::compute_edition[]
 * The container where you're embedding App-Embedded Defender can reach Console's port 8084 over the network.
 * You have Dockerfile for you image.
-* Azure CLI.
+* Cloud CLI, such as Azure CLI, or Google Cloud CLI.
 
 [.procedure]
 . Log into Prisma Cloud Console.
@@ -28,7 +28,7 @@ ifdef::compute_edition[]
 .. Go to *Manage > System > Utilities*, and download `twistcli` for your platform.
 endif::compute_edition[]
 
-. Run `twistcli` to embed Defender in Azure.
+. Run `twistcli` to embed Defender in your Cloud Registry (such as Azure, or Google Run).
 +
 A file named _app_embedded_embed_<app_id>.zip_ is created, that has the Dockerfile for App-Embedded Defender and App-Embedded Defender binary file.
 ifdef::compute_edition[]
@@ -75,7 +75,7 @@ In Console, the App ID is presented as the image name.
 
 . Unpack _app_embedded_embed_help.zip_.
 ifdef::app-embedded-defender-aci[]
-. Create and push the docker image to ACR.
+. Create and push the docker image to ACR
 
  $ az login
  $ docker login <Azure-ID> -u <Azure_username> -p <Access_key_password>
@@ -107,18 +107,39 @@ ifdef::app-embedded-defender-aci[]
   --memory 1.5
 endif::app-embedded-defender-aci[]
 ifdef::app-embedded-defender-gcr[]
-. Create and push the docker image to GCR.
-.. steps
-.. steps
-.. Verify the image built
-	docker images
-.. docker push <Registry>/REPO:TAG
+. Create and push the docker image to GCR
 
-.. Check the image exists in GCR repo
+.. Authenticate using GCP credentials:
 
-.. Create a container intance in GCR
+  $ gcloud auth login
+
+.. Or, Authenticate using GCP Service Account key (KEY-FILE): (Get the KEY-FILE from *GCP > Services Accounts > Actions > Manage keys*)
+  
+  $ gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE
+
+.. Configure Docker for GCP in your localhost
+
+   $ glcoud auth configure-docker
+
+.. Build the Dockerfile
+
+   $ docker build -t <GCP_Container_Registry>:<docker_images_name>  <local_path_host_dockerfile>
+   $ docker images ###Verify the image built
+
+.. Push the image to GCR
+
+   $ docker push HOSTNAME/PROJECT-ID/IMAGE:TAG
+
+.. Check the image exists in GCR repo under *GCP project > Container Registry > Images*
+
+.. Deploy Docker image in Google Cloud Run using `gcloud`
  
-  $ commands
+  $ gcloud run deploy [SERVICE] \
+  --image <IMAGE_URL> \
+  --platform managed \
+  --ingress <all> \
+  --cpu <CPU is always allocated> \
+  --port 8080
 
 endif::app-embedded-defender-gcr[]
 

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-with-dockerfile.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/embed-app-embedded-defender-with-dockerfile.adoc
@@ -1,0 +1,23 @@
+. Log in to Prisma Cloud Console.
+
+. Go to *Manage > Defenders > Deployed Defenders > Manual deploy*.
++
+image::deploy-app-embedded-defender-aci.gif[scale=20]
+
+. In Deployment method, select *Single Defender*.
+
+. Select the Defender type as *Container Defender - App-Embedded*.
+
+. Select the DNS name configured in *Manage > Defenders > Names (SAN)* or public IP address that Defender will use to connect to Prisma Console.
+
+. *Enable file system runtime protection* to allow the sensors to monitor file system events regardless of how your runtime policy is configured, and could impact the underlying workload's performance.
+
+. Select Deployment type as *Dockerfile*.
+.. In *App ID*, enter a unique identifier for the App-Embedded Defender.
+All vulnerability, compliance, and runtime findings for the container will be aggregated under this App ID. In Console, the App ID is presented as the image name. Be sure to specify an App ID that lets you easily trace findings back to the image.
+.. In *Data folder*, enter the path that the Defender will use to write files and store information.
+.. *Dockerfile*: Upload the Dockerfile for your container image.
+Set up the task's entrypoint in the Dockerfile. The embed process modifies the container's entrypoint to run the App-Embedded Defender first, which in turn starts the original entrypoint process. The Defender starts defending the app from the entrypoint and the thread/child process created by this entrypoint.
+
+. *Download* the App-embedded bundle that contains the Dockerfile with Defender deployment configurations appended to your Dockerfile and the App-Embedded Defender binary file.
+

--- a/compute/admin_guide/install/deploy-defender/app-embedded/fragments/view-deployed-defenders.adoc
+++ b/compute/admin_guide/install/deploy-defender/app-embedded/fragments/view-deployed-defenders.adoc
@@ -1,0 +1,32 @@
+ifdef::prisma_cloud[]
+You can review the list of all Defenders connected to Console under *Compute > Manage > Defenders > Deployed Defenders*.
+endif::prisma_cloud[]
+
+ifdef::compute_edition[]
+You can review the list of all Defenders connected to Console under *Manage > Defenders > Deployed Defenders*.
+endif::compute_edition[]
+
+To narrow the list to just App-Embedded Defenders, filter the table by type `Type: Container Defender - App-Embedded`.
+
+image::connected_app_embedded_defenders.png[scale=40]
+
+By default, Prisma Cloud removes disconnected App-Embedded Defenders from the list after an hour.
+As part of the cleanup process, data collected by the disconnected Defender is also removed from *Monitor > Runtime > App-Embedded observations*.
+
+ifdef::prisma_cloud[]
+[NOTE]
+====
+There is an advanced settings dialog under *Compute > Manage > Defenders > Deployed Defenders*, which lets you configure how long Prisma Cloud should wait before cleaning up disconnected Defenders.
+This setting doesn't apply to App-Embedded Defenders.
+Disconnected App-Embedded Defenders are always removed after one hour.
+====
+endif::prisma_cloud[]
+
+ifdef::compute_edition[]
+[NOTE]
+====
+There is an advanced settings dialog under *Manage > Defenders > Deployed Defenders*, which lets you configure how long Prisma Cloud should wait before cleaning up disconnected Defenders.
+This setting doesn't apply to App-Embedded Defenders.
+Disconnected App-Embedded Defenders are always removed after one hour.
+====
+endif::compute_edition[]


### PR DESCRIPTION
## Reference 

[CWP-49293](https://redlock.atlassian.net/browse/CWP-49293)

## Description

This is in continuation with the [PR#1401](https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/1401).

## Tasks

- [x] Use fragments for common sections
- [x] Modify the ACI page with fragments
- [x] Add a new page to deploy app-embedded Defender in GCR
