### PR TITLE
[App Security AG] Updated the book.yml with the correct GH bookdir

### DIFF
--- a/application-security/admin_guide/book.yml
+++ b/application-security/admin_guide/book.yml
@@ -23,7 +23,7 @@
 # topic groups and topics.
 ---
 kind: book
-title: Cloud Application Security
+title: Prisma Cloud Application Security Administrator's Guide
 version: 1.0.0
 author: Prisma Cloud Team
 ditamap: code-security-admin
@@ -32,7 +32,7 @@ graphics: techdocs/en_US/dita/_graphics/uv/prisma/prisma-cloud/prisma-cloud-admi
 github:
   owner: PaloAltoNetworks
   repo: prisma-cloud-docs
-  bookdir: code-security/admin_guide
+  bookdir: application-security/admin_guide
   branch: master
 ---
 kind: chapter


### PR DESCRIPTION
The book dir was code-security/admin_guide
now is application-security/admin_guide

