### PR TITLE
fix syntax and explanations in iam query attributes

### DIFF
--- a/cspm/rql-reference/rql-reference/iam-query/iam-query-attributes.adoc
+++ b/cspm/rql-reference/rql-reference/iam-query/iam-query-attributes.adoc
@@ -77,23 +77,31 @@ Lists GCP compute instances permissions:screen:[config from iam where source.clo
 
 * *source.cloud.resource.id*
 +
-Queries specific cloud resources by its id, such as AWS Lambda function ARN, AWS IAM user ARN, AWS EC2 instance ARN, any Azure resource ID, GCP user account or service. The following example lists all AWS Lambda function permissions:
+Queries permissions of a specific cloud resources by its id, such as AWS Lambda function ARN, AWS IAM user ARN, AWS EC2 instance ARN, any Azure resource ID, GCP user account, service, machine ID, etc. 
 +
-screen:[config from iam where source.cloud.resource.id = 'arn:aws:lambda:us-east-2:123456789012:function:my-function']The following lists permissions of a specific Azure virtual machine :
+The following example lists all AWS Lambda function permissions:
++
+screen:[config from iam where source.cloud.resource.id = 'arn:aws:lambda:us-east-2:123456789012:function:my-function']The following lists permissions of a specific Azure virtual machine:
 +
 screen:[config from iam where source.cloud.resource.id = '/subscriptions/aaaaa-bbb-ccc-ddd-eeeee/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachines/my-machine']
 
 * *source.cloud.resource.name*
 +
-Queries permissions of a specific cloud resource.  This can be any resource name that has IAM permissions in your environment, whether it be a user, group, machine, service account, etc.
+Queries permissions of a specific cloud resource by its name, such as AWS Lambda function, AWS IAM user, AWS EC2 instance, any Azure resource, GCP user account, service, machine, etc.  
 +
-For example:[config from iam where source.cloud.resource.name = 'my-lambda-function']
+The following example lists all permissions of a specific AWS Lambda function:
++
+screen:[config from iam where source.cloud.resource.name = 'my-lambda-function']The following example lists all permissions of a user:
++
+screen:[config from iam where source.cloud.resource.name = 'my-user']
 
 * *source.cloud.resource.type*
 +
-Queries permissions of a specific cloud type such as an IAM user, S3 bucket, EC2 instance, Azure AD user, varname:[Microsoft.Storage] storage account, varname:[Microsoft.compute] virtual machine, GCP Workspace user. The following example lists all AWS Lambda function permissions:
+Queries permissions of a specific cloud resource type such as an IAM user, S3 bucket, EC2 instance, Azure AD user, varname:[Microsoft.Storage] storage account, varname:[Microsoft.compute] virtual machine, GCP Workspace user, etc.. 
 +
-screen:[config from iam where source.cloud.service.name = 'lambda' AND source.cloud.resource.type = 'function']The following example lists all Azure function permissions:
+The following example lists all AWS Lambda functions and each of their permissions:
++
+screen:[config from iam where source.cloud.service.name = 'lambda' AND source.cloud.resource.type = 'function']The following example lists all Azure functions and each of their permissions:
 +
 screen:[config from iam where source.cloud.service.name = 'Microsoft.Compute' and source.cloud.resource.type = 'function']
 


### PR DESCRIPTION
- fixed code snippet under source.cloud.resoruce.name
- updated explanations and examples for the source.cloud.resoruce attributes to make them more uniform and easier to understand