### PR TITLE
Update onboard-aws.adoc

### DIFF
--- a/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
+++ b/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
@@ -1,6 +1,6 @@
 == Onboard AWS Accounts for Agentless Scanning
 
-Prisma Cloud gives you the flexibility to choose between agentless security and agent-based security using Defenders. Agentless scanning lets you inspect the risks and vulnerabilities of a cloud workload or container image without installing an agent or affecting the execution of your workload. Prisma Cloud supports agentless scanning for vulnerabilities and compliance on AWS hosts, containers, and clusters. To learn more about how agentless scanning works, see the xref:../agentless-scanning.adoc[How Agentless Scanning Works?]
+Prisma Cloud gives you the flexibility to choose between agentless security and agent-based security using Defenders. Agentless scanning lets you inspect the risks and vulnerabilities of a cloud workload or container image without installing an agent or affecting the execution of your workload. Prisma Cloud supports agentless scanning for vulnerabilities and compliance on AWS hosts, containers, and clusters. To learn more, see xref:../agentless-scanning.adoc[How Agentless Scanning Works?]
 
 To onboard your AWS account for agentless scanning, you need to complete the following tasks.
 

--- a/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
+++ b/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
@@ -1,6 +1,6 @@
 == Onboard AWS Accounts for Agentless Scanning
 
-Prisma Cloud gives you the flexibility to choose between agentless security and agent-based security using Defenders. Agentless scanning lets you inspect the risks and vulnerabilities of a cloud workload or container image without installing an agent or affecting the execution of your workload. Prisma Cloud supports agentless scanning for vulnerabilities and compliance on AWS hosts, containers, and clusters. To learn more about how agentless scanning works, see the xref:../agentless-scanning.adoc[How Agentless Scanning Works?][How Agentless Scanning Works?]
+Prisma Cloud gives you the flexibility to choose between agentless security and agent-based security using Defenders. Agentless scanning lets you inspect the risks and vulnerabilities of a cloud workload or container image without installing an agent or affecting the execution of your workload. Prisma Cloud supports agentless scanning for vulnerabilities and compliance on AWS hosts, containers, and clusters. To learn more about how agentless scanning works, see the xref:../agentless-scanning.adoc[How Agentless Scanning Works?]
 
 To onboard your AWS account for agentless scanning, you need to complete the following tasks.
 


### PR DESCRIPTION
REMOVED EXTRA WORDS | @Pubs-MV need to change link preview on line 9 to show "Aws" - Currently, it shows "GCP" instead, but we are on the AWS page. It does link correctly, however.

