### PR TITLE
[Compute PCCE RN: Correction] Remove blurb for CWP-50923 - this is still a Bug

### DIFF
--- a/compute/rn/release-information/release-notes-31-00.adoc
+++ b/compute/rn/release-information/release-notes-31-00.adoc
@@ -136,9 +136,6 @@ With this fix agentless scanning successfully  discovers containers on the speci
 +
 With this fix missing OS labels, both `osDistro` and `osVersion`, are added to hosts scanned by agentless scanning.
 
-* Fixed an issue where AKS cluster names were not properly processed and the cluster was incorrectly classified as a generic Kubernetes cluster instead of an AKS cluster.
-Now, the cluster names and their type are  properly parsed as AKS clusters.
-
 [#end-of-support]
 === End of Support Notifications
 

--- a/compute/rn/release-information/release-notes-31-01-update1.adoc
+++ b/compute/rn/release-information/release-notes-31-01-update1.adoc
@@ -118,10 +118,6 @@ By default, the Console is set to scan only 1 registry at a time. You can edit t
 //CWP-49173
 * Fixed a high CPU utilization issue when using WAAS sensitive data on Console versions 22.06 (Kepler) and higher. We fixed this issue by sampling traffic to discover just the APIs instead of inspecting every request (for example, we skip inspecting request body field, sensitive request, and response data).
 
-When upgrading the Console from v22.06 (Kepler) to v22.12 (Lagrange) and above, please disable sensitive data rules to fix the resource consumption issues.
-
-
-
 //[#backward-compatibility]
 //=== Backward Compatibility for New Features
 

--- a/compute/rn/release-information/release-notes-31-01-update1.adoc
+++ b/compute/rn/release-information/release-notes-31-01-update1.adoc
@@ -58,7 +58,7 @@ For example, you can upgrade from 22.12.693 to 30.02.123 and then upgrade to 31.
 === Enhancements
 
 //CWP-42985
-==== Severity Based Actions for Packages in Vulnerability Rules
+==== Severity-based Actions for Packages in Vulnerability Rules
 
 https://docs.paloaltonetworks.com/prisma/prisma-cloud/31/prisma-cloud-compute-edition-admin/vulnerability_management/vuln_management_rules[Vulnerability policy rules] can now be scoped based on the severity threshold per package, in addition to scoping the vulnerabilities by collections.
 You can now define the severity threshold per package type for alert and block actions.
@@ -114,10 +114,6 @@ By default, the Console is set to scan only 1 registry at a time. You can edit t
 
 //CWP-35771 //PCSUP-7591
 * Fixed an issue where node count was missing for EKS clusters under *Manage > Cloud accounts* cloud *Discovery* report. The correct node count is now displayed on the Console and in https://pan.dev/prisma-cloud/api/cwpp/get-cloud-discovery[API Cloud Discovery scan results].
-
-//CWP-50923
-* Fixed an issue where AKS cluster names were not properly processed and the cluster was incorrectly classified as a generic Kubernetes cluster instead of an AKS cluster.
-Now, the cluster names and their type are  properly parsed as AKS clusters.
 
 //CWP-49173
 * Fixed a high CPU utilization issue when using WAAS sensitive data on Console versions 22.06 (Kepler) and higher. We fixed this issue by sampling traffic to discover just the APIs instead of inspecting every request (for example, we skip inspecting request body field, sensitive request, and response data).


### PR DESCRIPTION
## Reference

Re-updating the `compute/rn/release-information/release-notes-31-01-update1.adoc` file to remove the blurb for `CWP-50923` (this is still a Bug).
My [commit](https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/1509/commits/46cdced83f9f7b22d5fdb04ec7711d0e75e21660) was replaced in the PR#1509 with this [commit](https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/1509/commits/9cc5c49b81b6306f53a2819ae6cc8670b3654e9f).

## Note

Please note and do not remove this bug from the Known Issues list as committed [here](https://github.com/PaloAltoNetworks/prisma-cloud-docs/pull/1509/commits/8cdf8c5740744d555a862803fca6db75b883f5a2) in the `compute/rn/release-information/known-issues-31.adoc` file.

Cc: @Pubs-MV 