### PR TITLE
Update onboard-aws.adoc

### DIFF
--- a/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
+++ b/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
@@ -303,7 +303,7 @@ ifdef::prisma_cloud[]
 
 To onboard your AWS account for agentless scanning in same account mode you need to complete the following tasks.
 
-. https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/connect-your-cloud-platform-to-prisma-cloud/onboard-aws[Onboard the GCP project] you want to use for agentless scanning in Prisma Cloud.
+. https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/connect-your-cloud-platform-to-prisma-cloud/onboard-aws[Onboard the AWS Account or AWS orginization] you want to use for agentless scanning in Prisma Cloud.
 
 . xref:./configure-aws.adoc[Configure] the onboarded account in Prisma Cloud.
 

--- a/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
+++ b/compute/admin_guide/agentless-scanning/onboard-accounts/onboard-aws.adoc
@@ -303,7 +303,7 @@ ifdef::prisma_cloud[]
 
 To onboard your AWS account for agentless scanning in same account mode you need to complete the following tasks.
 
-. https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/connect-your-cloud-platform-to-prisma-cloud/onboard-aws[Onboard the AWS Account or AWS orginization] you want to use for agentless scanning in Prisma Cloud.
+. https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/connect-your-cloud-platform-to-prisma-cloud/onboard-aws[Onboard the AWS Account or AWS organization] you want to use for agentless scanning in Prisma Cloud.
 
 . xref:./configure-aws.adoc[Configure] the onboarded account in Prisma Cloud.
 


### PR DESCRIPTION
Currently this Doc references onboarding a GCP Project for Agentless scanning when it should reference onboarding an AWS Account or Org.

