### PR TITLE
Fix syntax of description section in policy documentation

### DIFF
--- a/application-security/policy-reference/azure-policies/azure-general-policies/azr-general-85.adoc
+++ b/application-security/policy-reference/azure-policies/azure-general-policies/azr-general-85.adoc
@@ -23,7 +23,7 @@
 
 |=== 
 
-*Description*
+=== Description
 
 Azure AD authentication is a mechanism of connecting to Azure SQL Database by using identities in Azure AD. With Azure AD authentication, you can manage the identities of database users and other Microsoft services in one central location. It offers benefits like Multi-Factor Authentication, identity protection, and seamless domain join.
 

--- a/application-security/policy-reference/azure-policies/azure-general-policies/bc-azr-general-1.adoc
+++ b/application-security/policy-reference/azure-policies/azure-general-policies/bc-azr-general-1.adoc
@@ -24,10 +24,7 @@
 
 |=== 
 
-
-
-*Description* 
-
+=== Description
 
 Azure encrypts data disks by default Server-Side Encryption (SSE) with platform-managed keys [SSE with PMK].
 It is recommended to use either SSE with Azure Disk Encryption [SSE with PMK+ADE] or Customer Managed Key [SSE with CMK] which improves on platform-managed keys by giving you control of the encryption keys to meet your compliance needs.

--- a/application-security/policy-reference/azure-policies/azure-networking-policies/azr-networking-63.adoc
+++ b/application-security/policy-reference/azure-policies/azure-networking-policies/azr-networking-63.adoc
@@ -23,7 +23,7 @@
 
 |=== 
 
-*Description*
+=== Description
 
 Azure Web Apps are a fully managed platform for building, deploying, and scaling web apps. They can be configured to allow public access over the internet or restricted access through Virtual Networks and VPNs. This policy checks whether public network access to Azure Web Apps is disabled.
 

--- a/application-security/policy-reference/azure-policies/azure-networking-policies/azr-networking-64.adoc
+++ b/application-security/policy-reference/azure-policies/azure-networking-policies/azr-networking-64.adoc
@@ -23,7 +23,7 @@
 
 |=== 
 
-*Description*
+=== Description
 
 Azure Functions is a serverless compute service that enables you to run event-driven code without having to explicitly provision or manage infrastructure. It's essential to restrict public access to such applications to mitigate potential risks. This policy ensures that the public network access to Azure Function Apps is disabled. 
 


### PR DESCRIPTION
To maintain consistency, `*Description*` should have been `=== Description` in #1397 and #1512.