### PR TITLE
Remove unneeded host dependencies from localhost pre-receive setup 

### DIFF
--- a/application-security/admin_guide/get-started/add-pre-receive-hooks.adoc
+++ b/application-security/admin_guide/get-started/add-pre-receive-hooks.adoc
@@ -20,9 +20,7 @@ The Prisma Cloud Application Security pre-receive hook is supported on the follo
 
 . Fulfill the following requirements before installing the Prisma Application Security pre-receive hook on your local host:
 +
-* Install https://www.python.org/downloads/[Python] v3.7 - v3.11
 * Install https://docs.docker.com/get-docker/[Docker]
-* Install https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin-code-security/get-started/connect-your-repositories/add-checkov[Checkov]
 * Verify Administrator access to the Version Control System (VCS) server and console
 
 . Clone the repository: https://github.com/bridgecrewio/checkov-pre-receive-hooks.


### PR DESCRIPTION
Remove 2 links for things to install before the localhost install. Neither are needed because the steps run the script inside of the image, not on the host.

Also, one of the links 404s.