### PR TITLE
Update scan-reports.adoc

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/vulnerability-management/scan-reports.adoc
+++ b/docs/en/compute-edition/32/admin-guide/vulnerability-management/scan-reports.adoc
@@ -11,6 +11,7 @@ The initial scan is triggered when a Defender is installed, or when you enable a
 * Zero-day vulnerabilities
 * Compliance issues
 * Secrets
+
 After the initial scan, subsequent scans are triggered:
 
 * Periodically, according to the xref:../configure/configure-scan-intervals.adoc[scan interval] configured in Console. By default, images are scanned every 24 hours.


### PR DESCRIPTION
The bullet point list that details what the scans check for ends with "Secrets". Previously, this last bullet point contained the "After the initial scan ..." sentence as well. Addition of an extra space fixes this confusion.

